### PR TITLE
fix(security): prompt injection sanitization, rate limiting, and artists page fixes

### DIFF
--- a/lambda/enrichArtist.js
+++ b/lambda/enrichArtist.js
@@ -13,8 +13,21 @@ const VISION_API_KEY = process.env.GOOGLE_VISION_API_KEY
 const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${GEMINI_API_KEY}`
 const VISION_URL = `https://vision.googleapis.com/v1/images:annotate?key=${VISION_API_KEY}`
 
+// Strip characters that could break out of XML-like prompt tags or inject new instructions
+function sanitizeForPrompt(value, maxLength = 500) {
+  if (!value) return ''
+  return String(value)
+    .replace(/[<>]/g, '')        // remove tag delimiters
+    .replace(/[\x00-\x1F]/g, '') // remove control characters
+    .slice(0, maxLength)
+    .trim()
+}
+
 // ─── GEMINI: Extract tags from artist bio ─────────────────────────────────────
 async function extractTagsWithGemini(artistName, bio) {
+  const safeName = sanitizeForPrompt(artistName, 100)
+  const safeBio = sanitizeForPrompt(bio, 500) || 'No bio available. Generate tags based on name context only.'
+
   const prompt = `
 You are an art world expert. Given this artist's name and bio, extract structured tags.
 Return ONLY a JSON array of strings. No explanation, no markdown, no backticks.
@@ -28,8 +41,8 @@ Career stage MUST be one of these four exact strings (pick the best fit):
 
 Limit to 10 tags maximum (including the career stage).
 
-<artist_name>${artistName}</artist_name>
-<artist_bio>${bio || 'No bio available. Generate tags based on name context only.'}</artist_bio>
+<artist_name>${safeName}</artist_name>
+<artist_bio>${safeBio}</artist_bio>
 
 Example output: ["oil painting", "abstract expressionism", "New York", "mid-career artist", "portraiture"]
 `
@@ -57,9 +70,10 @@ Example output: ["oil painting", "abstract expressionism", "New York", "mid-care
 
 // ─── GEMINI: Generate artist bio ──────────────────────────────────────────────
 async function generateBioWithGemini(artistName) {
+  const safeName = sanitizeForPrompt(artistName, 100)
   const prompt = `
 Write a concise 2-sentence professional bio for the artist whose name is in <artist_name> tags.
-<artist_name>${artistName}</artist_name>
+<artist_name>${safeName}</artist_name>
 If this is a real artist you know, use factual information.
 If unknown, write a plausible art-world bio in a neutral tone.
 Do not fabricate specific exhibition dates or gallery names.

--- a/lib/api/validators.js
+++ b/lib/api/validators.js
@@ -39,7 +39,8 @@ const getArtworkByIdSchema = z.object({
  */
 const getArtistsSchema = paginationSchema.extend({
   search: z.string().max(100).optional(),
-  orderBy: z.enum(['name', 'createdAt']).default('name').optional()
+  orderBy: z.enum(['name', 'createdAt']).default('name').optional(),
+  careerStage: z.enum(['emerging artist', 'mid-career artist', 'established artist', 'late-career artist']).optional()
 });
 
 /**

--- a/lib/middleware/rateLimit.js
+++ b/lib/middleware/rateLimit.js
@@ -11,7 +11,8 @@
  * for a Redis counter using INCR + EXPIRE.
  */
 
-// Map<ip, { count, windowStart }>
+// Map<"routeKey:ip", { count, windowStart, windowMs }>
+// Key includes the route so limits on one endpoint don't consume another's budget
 const store = new Map();
 
 // Prune stale entries every 5 minutes to avoid unbounded growth
@@ -26,13 +27,16 @@ setInterval(() => {
 
 /**
  * @param {Function} handler
- * @param {{ windowMs?: number, max?: number }} options
+ * @param {{ windowMs?: number, max?: number, routeKey?: string }} options
  *   windowMs  – rolling window length in ms (default 60 000)
  *   max       – max requests per window per IP (default 60)
+ *   routeKey  – stable identifier for this route (default 'default')
+ *               Must be set per-route so limits don't bleed across endpoints
  */
 function withRateLimit(handler, options = {}) {
   const windowMs = options.windowMs || 60_000;
   const max = options.max || 60;
+  const routeKey = options.routeKey || 'default';
 
   return async (req, res) => {
     const ip =
@@ -40,11 +44,12 @@ function withRateLimit(handler, options = {}) {
       req.socket?.remoteAddress ||
       'unknown';
 
+    const storeKey = `${routeKey}:${ip}`;
     const now = Date.now();
-    const entry = store.get(ip);
+    const entry = store.get(storeKey);
 
     if (!entry || now - entry.windowStart >= windowMs) {
-      store.set(ip, { count: 1, windowStart: now, windowMs });
+      store.set(storeKey, { count: 1, windowStart: now, windowMs });
     } else {
       entry.count += 1;
       if (entry.count > max) {

--- a/pages/api/artworks.js
+++ b/pages/api/artworks.js
@@ -3,8 +3,9 @@
 // Falls back to legacy mytable if v2 has no data yet
 
 import { prisma } from '../../prisma/globalprisma'
+import { withRateLimit } from '../../lib/middleware/rateLimit'
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
@@ -85,3 +86,5 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'Failed to fetch artworks' })
   }
 }
+
+export default withRateLimit(handler, { windowMs: 60_000, max: 60, routeKey: 'artworks-v1' })

--- a/pages/api/v2/artists/[id].js
+++ b/pages/api/v2/artists/[id].js
@@ -24,6 +24,7 @@
 import { prisma } from '../../../../prisma/globalprisma';
 import { successResponse } from '../../../../lib/api/handlers';
 import { withRedisCache } from '../../../../lib/middleware/redisCache';
+import { withRateLimit } from '../../../../lib/middleware/rateLimit';
 
 async function handler(req, res) {
   try {
@@ -97,8 +98,10 @@ async function handler(req, res) {
   }
 }
 
-export default withRedisCache(handler, {
-  ttl: 86400, // 24 hours (artists rarely change)
+const cachedHandler = withRedisCache(handler, {
+  ttl: 86400,
   key: 'artists:detail',
-  keyGenerator: (req) => `artists:detail:${req.query.id}`
+  keyGenerator: (req) => `artists:detail:${parseInt(req.query.id, 10) || 'invalid'}`
 });
+
+export default withRateLimit(cachedHandler, { windowMs: 60_000, max: 60, routeKey: 'artists-v2-detail' });

--- a/pages/api/v2/artists/index.js
+++ b/pages/api/v2/artists/index.js
@@ -38,17 +38,16 @@ async function handler(req, res) {
 
     // Validate query parameters
     const query = getArtistsSchema.parse(req.query);
-    const { limit = 20, offset = 0, search, orderBy = 'name' } = query;
+    const { limit = 20, offset = 0, search, orderBy = 'name', careerStage } = query;
 
     // Build the where clause
-    const where = search
-      ? {
-          name: {
-            contains: search,
-            mode: 'insensitive'
-          }
-        }
-      : {};
+    const where = {};
+    if (search) {
+      where.name = { contains: search, mode: 'insensitive' };
+    }
+    if (careerStage) {
+      where.comprehend_tags = { has: careerStage };
+    }
 
     // Determine order by field
     const order = {};
@@ -58,10 +57,13 @@ async function handler(req, res) {
       order.createdAt = 'desc';
     }
 
-    // Execute queries in parallel
-    const [artists, total] = await Promise.all([
+    const CAREER_STAGES = ['emerging artist', 'mid-career artist', 'established artist', 'late-career artist'];
+    const whereClause = Object.keys(where).length > 0 ? where : undefined;
+
+    // Execute queries in parallel, including per-stage counts for the sidebar
+    const [artists, total, ...stageCountResults] = await Promise.all([
       prisma.artist.findMany({
-        where: Object.keys(where).length > 0 ? where : undefined,
+        where: whereClause,
         skip: offset,
         take: limit,
         orderBy: order,
@@ -83,10 +85,17 @@ async function handler(req, res) {
           }
         }
       }),
-      prisma.artist.count({
-        where: Object.keys(where).length > 0 ? where : undefined
-      })
+      prisma.artist.count({ where: whereClause }),
+      ...CAREER_STAGES.map(stage =>
+        prisma.artist.count({
+          where: { ...where, comprehend_tags: { has: stage } }
+        })
+      )
     ]);
+
+    const stageCounts = Object.fromEntries(
+      CAREER_STAGES.map((stage, i) => [stage, stageCountResults[i]])
+    );
 
     // Format response
     const formattedArtists = artists.map(artist => ({
@@ -107,7 +116,8 @@ async function handler(req, res) {
           limit,
           total,
           hasMore: offset + artists.length < total
-        }
+        },
+        stageCounts
       })
     );
   } catch (error) {

--- a/pages/api/v2/artists/index.js
+++ b/pages/api/v2/artists/index.js
@@ -144,6 +144,7 @@ export default withRedisCache(handler, {
     const offset = parseInt(req.query.offset, 10) || 0;
     const search = sanitizeCacheSegment(req.query.search) || 'all';
     const orderBy = req.query.orderBy === 'createdAt' ? 'createdAt' : 'name';
-    return `artists:list:${limit}:${offset}:${search}:${orderBy}`;
+    const careerStage = sanitizeCacheSegment(req.query.careerStage) || 'all';
+    return `artists:list:${limit}:${offset}:${search}:${orderBy}:${careerStage}`;
   }
 });

--- a/pages/api/v2/artworks/[id].js
+++ b/pages/api/v2/artworks/[id].js
@@ -18,6 +18,7 @@
 import { prisma } from '../../../../prisma/globalprisma';
 import { successResponse } from '../../../../lib/api/handlers';
 import { withRedisCache } from '../../../../lib/middleware/redisCache';
+import { withRateLimit } from '../../../../lib/middleware/rateLimit';
 
 async function handler(req, res) {
   try {
@@ -91,8 +92,10 @@ async function handler(req, res) {
   }
 }
 
-export default withRedisCache(handler, {
-  ttl: 3600, // 1 hour
+const cachedHandler = withRedisCache(handler, {
+  ttl: 3600,
   key: 'artworks:detail',
-  keyGenerator: (req) => `artworks:detail:${req.query.id}`
+  keyGenerator: (req) => `artworks:detail:${parseInt(req.query.id, 10) || 'invalid'}`
 });
+
+export default withRateLimit(cachedHandler, { windowMs: 60_000, max: 60, routeKey: 'artworks-v2-detail' });

--- a/pages/api/v2/artworks/index.js
+++ b/pages/api/v2/artworks/index.js
@@ -25,6 +25,7 @@ import { prisma } from '../../../../prisma/globalprisma';
 import { successResponse } from '../../../../lib/api/handlers';
 import { getArtworksSchema } from '../../../../lib/api/validators';
 import { withRedisCache } from '../../../../lib/middleware/redisCache';
+import { withRateLimit } from '../../../../lib/middleware/rateLimit';
 
 async function handler(req, res) {
   try {
@@ -105,8 +106,21 @@ async function handler(req, res) {
   }
 }
 
-export default withRedisCache(handler, {
-  ttl: 3600, // 1 hour
+function sanitizeCacheSegment(value) {
+  if (!value) return '';
+  return String(value).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64);
+}
+
+const cachedHandler = withRedisCache(handler, {
+  ttl: 3600,
   key: 'artworks:list',
-  keyGenerator: (req) => `artworks:list:${req.query.limit}:${req.query.offset}:${req.query.artistId || 'all'}:${req.query.search || 'all'}`
+  keyGenerator: (req) => {
+    const limit = parseInt(req.query.limit, 10) || 20;
+    const offset = parseInt(req.query.offset, 10) || 0;
+    const artistId = parseInt(req.query.artistId, 10) || 'all';
+    const search = sanitizeCacheSegment(req.query.search) || 'all';
+    return `artworks:list:${limit}:${offset}:${artistId}:${search}`;
+  }
 });
+
+export default withRateLimit(cachedHandler, { windowMs: 60_000, max: 60, routeKey: 'artworks-v2-list' });

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,7 +65,7 @@ export default function Home() {
 
           <a href="/posts/artists" className="card">
             <h3>Artists &rarr;</h3>
-            <p>Browse all 67 artists</p>
+            <p>Search every artist ZXY has shown. Filter by career stage, read AI-generated bios, and see who's trending now.</p>
           </a>
 
           <a href="/trending" className="card">

--- a/pages/posts/artists.js
+++ b/pages/posts/artists.js
@@ -365,35 +365,40 @@ export default function ArtistsPage({ initialArtists, totalCount }) {
 }
 
 export async function getServerSideProps() {
-  const { prisma } = require('../../prisma/globalprisma');
+  try {
+    const { prisma } = require('../../prisma/globalprisma');
 
-  const [artists, total] = await Promise.all([
-    prisma.artist.findMany({
-      take: 24,
-      orderBy: { name: 'asc' },
-      select: {
-        id: true,
-        name: true,
-        bio: true,
-        comprehend_tags: true,
-        gallery_links: {
-          take: 1,
-          select: {
-            gallery: { select: { name: true, city: true } }
+    const [artists, total] = await Promise.all([
+      prisma.artist.findMany({
+        take: 24,
+        orderBy: { name: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          bio: true,
+          comprehend_tags: true,
+          gallery_links: {
+            take: 1,
+            select: {
+              gallery: { select: { name: true, city: true } }
+            }
           }
         }
-      }
-    }),
-    prisma.artist.count()
-  ]);
+      }),
+      prisma.artist.count()
+    ]);
 
-  const formatted = artists.map(a => ({
-    id: a.id.toString(),
-    name: a.name,
-    bio: a.bio || null,
-    comprehend_tags: a.comprehend_tags || [],
-    gallery: a.gallery_links?.[0]?.gallery || null,
-  }));
+    const formatted = artists.map(a => ({
+      id: a.id.toString(),
+      name: a.name,
+      bio: a.bio || null,
+      comprehend_tags: a.comprehend_tags || [],
+      gallery: a.gallery_links?.[0]?.gallery || null,
+    }));
 
-  return { props: { initialArtists: formatted, totalCount: total } };
+    return { props: { initialArtists: formatted, totalCount: total } };
+  } catch (err) {
+    console.error('getServerSideProps /posts/artists failed:', err.message);
+    return { props: { initialArtists: [], totalCount: 0 } };
+  }
 }

--- a/pages/posts/artists.js
+++ b/pages/posts/artists.js
@@ -3,7 +3,7 @@
  * Showcases all artists with search, career stage filter, and trending rankings
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 
@@ -116,6 +116,12 @@ export default function ArtistsPage({ initialArtists, totalCount }) {
   const [trendWindow, setTrendWindow] = useState('7d');
   const [trending, setTrending] = useState([]);
   const [trendLoading, setTrendLoading] = useState(true);
+  const [stageCounts, setStageCounts] = useState(() =>
+    CAREER_STAGES.slice(1).reduce((acc, s) => {
+      acc[s] = initialArtists?.filter(a => (a.comprehend_tags || []).includes(s)).length || 0;
+      return acc;
+    }, {})
+  );
 
   const LIMIT = 24;
 
@@ -133,6 +139,7 @@ export default function ArtistsPage({ initialArtists, totalCount }) {
       limit: LIMIT,
       offset: page * LIMIT,
       ...(debouncedSearch && { search: debouncedSearch }),
+      ...(careerFilter !== 'all' && { careerStage: careerFilter }),
     });
 
     fetch(`/api/v2/artists?${params}`)
@@ -140,14 +147,9 @@ export default function ArtistsPage({ initialArtists, totalCount }) {
       .then(data => {
         if (!active) return;
         if (data.status === 'success') {
-          let results = data.data || [];
-          if (careerFilter !== 'all') {
-            results = results.filter(a =>
-              (a.comprehend_tags || []).includes(careerFilter)
-            );
-          }
-          setArtists(results);
+          setArtists(data.data || []);
           setTotal(data.meta?.pagination?.total || 0);
+          if (data.meta?.stageCounts) setStageCounts(data.meta.stageCounts);
         }
       })
       .finally(() => { if (active) setLoading(false); });
@@ -168,11 +170,6 @@ export default function ArtistsPage({ initialArtists, totalCount }) {
 
   // Reset page on filter change
   useEffect(() => { setPage(0); }, [debouncedSearch, careerFilter]);
-
-  const stageCounts = CAREER_STAGES.slice(1).reduce((acc, s) => {
-    acc[s] = initialArtists?.filter(a => (a.comprehend_tags || []).includes(s)).length || 0;
-    return acc;
-  }, {});
 
   return (
     <>

--- a/scripts/re-enrich-tags.js
+++ b/scripts/re-enrich-tags.js
@@ -11,7 +11,16 @@ const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY
-const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`
+const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${GEMINI_API_KEY}`
+
+function sanitizeForPrompt(value, maxLength = 500) {
+  if (!value) return ''
+  return String(value)
+    .replace(/[<>]/g, '')
+    .replace(/[\x00-\x1F]/g, '')
+    .slice(0, maxLength)
+    .trim()
+}
 
 const VALID_CAREER_STAGES = [
   'emerging artist',
@@ -21,6 +30,9 @@ const VALID_CAREER_STAGES = [
 ]
 
 async function extractTagsWithGemini(artistName, bio) {
+  const safeName = sanitizeForPrompt(artistName, 100)
+  const safeBio = sanitizeForPrompt(bio, 500) || 'No bio available. Generate tags based on name context only.'
+
   const prompt = `
 You are an art world expert. Given this artist's name and bio, extract structured tags.
 Return ONLY a JSON array of strings. No explanation, no markdown, no backticks.
@@ -34,8 +46,8 @@ Career stage MUST be one of these four exact strings (pick the best fit):
 
 Limit to 10 tags maximum (including the career stage).
 
-Artist: ${artistName}
-Bio: ${bio || 'No bio available. Generate tags based on name context only.'}
+Artist: ${safeName}
+Bio: ${safeBio}
 
 Example output: ["oil painting", "abstract expressionism", "New York", "mid-career artist", "portraiture"]
 `


### PR DESCRIPTION
## Summary

- **Prompt injection prevention**: Added `sanitizeForPrompt()` to `lambda/enrichArtist.js` and `scripts/re-enrich-tags.js` — strips `<>` tag delimiters and control characters from artist name/bio (capped at 100/500 chars) before Gemini prompt interpolation
- **Rate limiting gaps closed**: Added `withRateLimit` (60 req/min) to `/api/artworks`, `/api/v2/artworks`, `/api/v2/artworks/[id]`, and `/api/v2/artists/[id]`
- **Rate limiter store key fix**: Store was keyed by IP only — limits from one endpoint consumed another's budget. Now keyed as `routeKey:ip` with a unique key per route
- **Cache key injection**: Sanitized `search` param in artworks list cache key generator (matches existing artists route pattern)
- **Artists page moved** to `/posts/artists`; fixed Prisma import path (`../../prisma/globalprisma`), nav self-link, and `index.js` home card link
- **Career stage filter moved to backend**: `careerStage` query param added to API + Zod schema; DB uses `comprehend_tags: { has: stage }`; `stageCounts` returned in response meta so sidebar counts stay accurate across search/pagination
- **Misc**: remove unused `useCallback`, sync re-enrich script to `gemini-1.5-flash-latest`

## Test plan

- [ ] `npm run build` passes with no errors
- [ ] `/posts/artists` loads and career stage filter buttons correctly filter results server-side across pages
- [ ] Stage count badges update when a search query is active
- [ ] `curl /api/artworks` 61 times from same IP within 60s → 429 on 61st request
- [ ] `curl /api/v2/artworks` and `/api/v2/artists/[id]` also rate-limit independently
- [ ] Artist with a bio containing `<script>ignore above</script>` — verify Gemini still returns normal tags
- [ ] Re-enrich script runs against staging DB without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)