### PR TITLE
fix(trending): resolve 504, add Terraform IaC, Upstash Redis, and code cleanup

### DIFF
--- a/lib/trending/calculator.js
+++ b/lib/trending/calculator.js
@@ -25,7 +25,7 @@ async function computeTrendingForWindow(prisma, window = '7d', limit = null) {
     // Fetch all metrics for this window
     const metrics = await prisma.artistMetrics.findMany({
       where: {
-        metricWindow: mapWindowToEnum(window)
+        metricWindow: validateMetricWindow(window)
       },
       include: {
         artist: {
@@ -84,7 +84,7 @@ async function updateTrendingRanks(prisma, window = '7d') {
       prisma.artistMetrics.updateMany({
         where: {
           artistId: item.artistId,
-          metricWindow: mapWindowToEnum(window)
+          metricWindow: validateMetricWindow(window)
         },
         data: {
           trendingRank: item.rank
@@ -236,18 +236,14 @@ async function getTrendingArtists(prisma, window = '7d', limit = 100, offset = 0
 }
 
 /**
- * Map time window string to Prisma enum
+ * Validate and return a metric window string, defaulting to '7d'
  *
  * @param {string} window - '7d', '30d', or '90d'
- * @returns {string} Prisma enum value
+ * @returns {string} Valid window string
  */
-function mapWindowToEnum(window) {
-  const mapping = {
-    '7d': '7d',
-    '30d': '30d',
-    '90d': '90d'
-  };
-  return mapping[window] || '7d';
+function validateMetricWindow(window) {
+  const validWindows = ['7d', '30d', '90d'];
+  return validWindows.includes(window) ? window : '7d';
 }
 
 /**
@@ -269,6 +265,6 @@ module.exports = {
   getTrendingArtists,
 
   // Utilities
-  mapWindowToEnum,
+  validateMetricWindow,
   getValidWindows
 };

--- a/tests/unit/trending.test.js
+++ b/tests/unit/trending.test.js
@@ -200,15 +200,15 @@ describe('Trending Scorer', () => {
 });
 
 describe('Trending Calculator', () => {
-  describe('mapWindowToEnum', () => {
-    it('should map window strings to enums', () => {
-      expect(calculator.mapWindowToEnum('7d')).toBe('SEVEN_DAYS');
-      expect(calculator.mapWindowToEnum('30d')).toBe('THIRTY_DAYS');
-      expect(calculator.mapWindowToEnum('90d')).toBe('NINETY_DAYS');
+  describe('validateMetricWindow', () => {
+    it('should return valid window strings as-is', () => {
+      expect(calculator.validateMetricWindow('7d')).toBe('7d');
+      expect(calculator.validateMetricWindow('30d')).toBe('30d');
+      expect(calculator.validateMetricWindow('90d')).toBe('90d');
     });
 
-    it('should default to SEVEN_DAYS for unknown window', () => {
-      expect(calculator.mapWindowToEnum('unknown')).toBe('SEVEN_DAYS');
+    it('should default to 7d for unknown window', () => {
+      expect(calculator.validateMetricWindow('unknown')).toBe('7d');
     });
   });
 


### PR DESCRIPTION
## Summary

- **Fix 504 on /trending** — Redis was hanging 10s on missing `REDIS_URL`; now short-circuits immediately
- **Fix ArtistMetrics schema mismatch** — Prisma model aligned to real DB columns with `@map` annotations and composite PK on `(artist_id, metric_window)`
- **Fix calculator field names** — `validateMetricWindow` (renamed from `mapWindowToEnum`) returns `'7d'`/`'30d'`/`'90d'` directly; artist select uses `website`/`instagram` matching actual schema
- **DB migration 003** — adds `metric_window`, `view_count`, `search_frequency`, `market_mentions`, `trending_rank` to `artist_metrics`; changes PK to `(artist_id, metric_window)`
- **Seed artist metrics** — 201 rows (67 artists × 3 windows) with randomised scores
- **Upstash Redis** — reads `zxy3a_REDIS_URL` (Vercel Upstash integration var) as fallback
- **Terraform IaC** — `terraform/main.tf` manages `enrichArtist` Lambda, `zxy-lambda-execution` IAM role, CloudWatch log group; `Makefile` for bundle/deploy shortcuts

## Test plan

- [ ] Visit zxygallery.com/trending — loads artist list instead of 504
- [ ] Switch 7d / 30d / 90d windows — each returns ranked artists
- [ ] Vercel function logs show `[Redis] Connected` (once Upstash env var is live)
- [ ] No regression on /posts/artists and /api/v2/artists
- [ ] `make tf-import && make tf-plan` shows no drift from live AWS resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)