### PR TITLE
fix(trending): populate trendingRank and fix 500 on /api/v2/trending/artists

### DIFF
--- a/pages/api/v2/trending/artists.js
+++ b/pages/api/v2/trending/artists.js
@@ -121,4 +121,4 @@ const cachedHandler = withRedisCache(handler, {
   }
 });
 
-export default withRateLimit(cachedHandler, { windowMs: 60_000, max: 20 });
+export default withRateLimit(cachedHandler, { windowMs: 60_000, max: 20, routeKey: 'trending:artists' });

--- a/scripts/run-trending-ranks.js
+++ b/scripts/run-trending-ranks.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/**
+ * Run Trending Ranks Pipeline
+ *
+ * Computes and updates trendingRank for all artists across all windows (7d, 30d, 90d)
+ *
+ * Usage:
+ *   node scripts/run-trending-ranks.js
+ */
+
+const { PrismaClient } = require('@prisma/client');
+const { computeAllTrending } = require('../lib/trending/calculator');
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('Running trending rank computation for all windows (7d, 30d, 90d)...');
+
+  try {
+    const result = await computeAllTrending(prisma);
+
+    if (result.status === 'success') {
+      console.log(`\nCompleted successfully. Total artists updated: ${result.totalUpdated}`);
+      for (const [window, data] of Object.entries(result.results)) {
+        console.log(`  ${window}: ${data.updated} artists ranked`);
+      }
+    } else {
+      console.error('\nComputation failed:', result.error);
+      process.exit(1);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  prisma.$disconnect();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Fix 500 on trending endpoint**: `withRateLimit` was missing `routeKey` on `/api/v2/trending/artists`, causing a throw at module load time — every request 500'd before any handler logic ran
- **Fix schema/504 issues**: Prisma schema now matches real DB columns with `@map` annotations and composite PK; `validateMetricWindow` returns plain strings not enum values; Redis short-circuits immediately when `REDIS_URL` is unset (was hanging 10s causing all 504s)
- **Upstash Redis fallback**: reads `zxy3a_REDIS_URL` env var injected by the Vercel/Upstash integration
- **Run trending ranks pipeline**: confirmed 67 artists ranked across 7d/30d/90d windows locally; `trendingRank` column is populated in DB
- **Manual pipeline script**: `scripts/run-trending-ranks.js` for re-running ranks outside the hourly cron
- **Terraform IaC**: manages enrichArtist Lambda, IAM role, and CloudWatch logs
- **Artists page fixes**: security hardening (prompt injection sanitization, rate limiting on all routes, cache key fixes), 500 fixes on `/posts/artists`

## Test plan

- [ ] Verify `/api/v2/trending/artists?window=7d` returns 200 with ranked artists in the new Vercel preview deployment
- [ ] Check Vercel runtime logs show no `withRateLimit` errors
- [ ] Confirm `trendingRank` is non-null for artists in DB (`7d`, `30d`, `90d` windows)
- [ ] Run `node scripts/run-trending-ranks.js` to re-populate ranks on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)