### PR TITLE
fix(trending): graceful shutdown in run-trending-ranks script

### DIFF
--- a/scripts/run-trending-ranks.js
+++ b/scripts/run-trending-ranks.js
@@ -26,8 +26,7 @@ async function main() {
         console.log(`  ${window}: ${data.updated} artists ranked`);
       }
     } else {
-      console.error('\nComputation failed:', result.error);
-      process.exit(1);
+      throw new Error(result.error);
     }
   } finally {
     await prisma.$disconnect();
@@ -36,6 +35,5 @@ async function main() {
 
 main().catch(err => {
   console.error('Fatal error:', err.message);
-  prisma.$disconnect();
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

- Throw instead of `process.exit(1)` inside `try` so the `finally` block always runs and disconnects Prisma before exit
- Remove redundant non-awaited `prisma.$disconnect()` from `.catch` (the `finally` already handles it)

Addresses Gemini code review comments on #112.

## Test plan

- [ ] `node scripts/run-trending-ranks.js` completes without dangling DB connections
- [ ] On computation failure, process exits 1 after Prisma disconnects cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)