### PR TITLE
Add B2B artist momentum radar frontend

### DIFF
--- a/data/top-gallery-signals.json
+++ b/data/top-gallery-signals.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Art Basel",
+    "category": "art_fair",
+    "tier": "mega",
+    "aliases": []
+  },
+  {
+    "name": "Carpenter's Workshop Gallery",
+    "category": "commercial",
+    "tier": "major",
+    "aliases": ["Carpenter's Workshop"]
+  },
+  {
+    "name": "Clearing",
+    "category": "commercial",
+    "tier": "major",
+    "aliases": ["CLEARING"]
+  },
+  {
+    "name": "David Zwirner",
+    "category": "commercial",
+    "tier": "mega",
+    "aliases": []
+  },
+  {
+    "name": "Frieze LA",
+    "category": "art_fair",
+    "tier": "major",
+    "aliases": ["Frieze"]
+  },
+  {
+    "name": "Luhring Augustine",
+    "category": "commercial",
+    "tier": "major",
+    "aliases": []
+  },
+  {
+    "name": "Magenta Plains",
+    "category": "commercial",
+    "tier": "major",
+    "aliases": []
+  },
+  {
+    "name": "Mana Contemporary",
+    "category": "non_profit",
+    "tier": "major",
+    "aliases": []
+  },
+  {
+    "name": "Tanya Bonakdar Gallery",
+    "category": "commercial",
+    "tier": "major",
+    "aliases": ["Tanya Bonakdar", "Tanya Bondakar Gallery"]
+  },
+  {
+    "name": "The Armory Show",
+    "category": "art_fair",
+    "tier": "major",
+    "aliases": []
+  },
+  {
+    "name": "Tiger Strikes Asteroid",
+    "category": "artist_run",
+    "tier": "major",
+    "aliases": []
+  }
+]

--- a/docs/b2b-spinout-implementation-guide.md
+++ b/docs/b2b-spinout-implementation-guide.md
@@ -1,0 +1,749 @@
+# B2B Spinout Implementation Guide
+
+**Created:** May 7, 2026  
+**Purpose:** Implementation roadmap for the first three B2B products that can be spun out from the current ZXY data collection, enrichment, gallery audit, and trending infrastructure.
+
+---
+
+## Executive Summary
+
+Build the first three products as one shared intelligence platform:
+
+1. **Artist Momentum Radar** - ranked artist discovery and trend dashboards.
+2. **Roster & Representation Change Alerts** - alerts when artist-gallery relationships change or become more valuable.
+3. **Verified Gallery Intelligence API** - a clean B2B feed of gallery, artist, relationship, status, and verification data.
+
+The strongest product wedge is not a generic art directory. It is a verified signal system for the art market:
+
+- Who is gaining momentum?
+- Which galleries represent, show, or recently showed them?
+- Which galleries are active, unreachable, relocated, or changing?
+- What changed since the last verification run?
+- Can another business consume this data reliably by dashboard, alerts, CSV, or API?
+
+The first three products should share one data layer, one verification workflow, and one scoring engine. The commercial packaging can be separate.
+
+---
+
+## Current Local Assets
+
+Use the existing repo as the foundation:
+
+| Asset | File | Product Value |
+|---|---|---|
+| Artist records | `data/artists-consolidated.csv` | Base entity list, artist websites, Instagram, CV URLs, gallery history |
+| Gallery records | `data/galleries-consolidated.csv` | Gallery entity list, location, type, website, status |
+| Artist-gallery links | `data/artist-gallery-consolidated.csv` | Relationship graph for roster and representation intelligence |
+| Gallery audit tooling | `scripts/audit_galleries.py` | Verification engine for Gallery Intelligence API |
+| Gallery enrichment tooling | `scripts/enrich_galleries.py` | Batch fixes and status updates |
+| Artist enrichment tooling | `scripts/extract-social-and-cv.py` | CV and Instagram discovery |
+| Trending system | `docs/trending-system.md` and `lib/trending/` | Existing ranking infrastructure |
+| Upcoming openings | `data/upcoming-openings.md` | Early event signal source |
+| API v2 plan | `docs/API_V2.md` | Existing endpoint conventions |
+
+Current data shape as of the latest local inspection:
+
+- 52 galleries, with 40 active and 12 marked `inactive_website_unreachable`.
+- 579 artists.
+- 513 artists with `galleries_exhibited`.
+- 48 artists with websites.
+- 43 artists with CV URLs.
+- 24 artists with Instagram URLs.
+- Existing trend scoring supports internal metrics and external metrics.
+
+---
+
+## Platform Architecture
+
+Treat the platform as four layers:
+
+1. **Entity Layer**
+   - Artists
+   - Galleries
+   - Artist-gallery relationships
+   - Exhibitions and events
+   - Source evidence
+
+2. **Verification Layer**
+   - Website reachability
+   - Instagram validity
+   - Gallery status
+   - Last verified dates
+   - Source confidence
+
+3. **Signal Layer**
+   - Momentum scores
+   - Relationship changes
+   - Gallery status changes
+   - Exhibition and fair appearances
+   - CV-derived career milestones
+
+4. **Product Layer**
+   - Dashboard for Artist Momentum Radar
+   - Alerts for roster and representation changes
+   - API/feed for Verified Gallery Intelligence
+
+---
+
+## Shared Data Model
+
+The existing Prisma schema already has `Artist`, `Gallery`, `ArtistGallery`, and `ArtistMetrics`. Add the minimum additional models needed for commercial-grade freshness and explainability.
+
+Implementation note: the model snippets below are intentionally focused on the new tables. When copying them into `prisma/schema.prisma`, also add the corresponding inverse relation arrays to `Artist` and `Gallery` where Prisma requires them.
+
+### Source Evidence
+
+Every important claim should have a source. This makes the data sellable.
+
+Recommended model:
+
+```prisma
+model SourceEvidence {
+  id           BigInt   @id @default(sequence())
+  entityType   String   @map("entity_type") // artist | gallery | relationship | event
+  entityId     String   @map("entity_id")
+  fieldName    String   @map("field_name")
+  value        String?
+  sourceUrl    String?  @map("source_url")
+  sourceType   String   @map("source_type") // website | instagram | artsy | cv | manual | scraper
+  confidence   Float    @default(0.75)
+  observedAt   DateTime @default(now()) @map("observed_at")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@index([entityType, entityId])
+  @@index([fieldName, observedAt])
+  @@map("source_evidence")
+}
+```
+
+### Gallery Verification Snapshot
+
+This powers the Verified Gallery Intelligence API and the gallery change alerts.
+
+```prisma
+model GalleryVerificationSnapshot {
+  id             BigInt   @id @default(sequence())
+  galleryId      Int      @map("gallery_id")
+  website        String?
+  httpStatus     Int?     @map("http_status")
+  status         String   // active | unreachable | closed | relocated | unknown
+  instagram      String?
+  artistCount    Int?     @map("artist_count")
+  locationsHash  String?  @map("locations_hash")
+  verifiedAt     DateTime @default(now()) @map("verified_at")
+
+  gallery        Gallery  @relation(fields: [galleryId], references: [id])
+
+  @@index([galleryId, verifiedAt])
+  @@index([status, verifiedAt])
+  @@map("gallery_verification_snapshots")
+}
+```
+
+### Artist Signal Snapshot
+
+This gives the Momentum Radar a durable history instead of only a current rank.
+
+```prisma
+model ArtistSignalSnapshot {
+  id                   BigInt   @id @default(sequence())
+  artistId             BigInt   @map("artist_id")
+  window               String   // 7d | 30d | 90d
+  momentumScore         Float    @map("momentum_score")
+  rank                 Int?
+  percentile           Float?
+  scoringMode          String?  @map("scoring_mode")
+  instagramFollowers   Int?     @map("instagram_followers")
+  soloShowCount        Int      @default(0) @map("solo_show_count")
+  groupShowCount       Int      @default(0) @map("group_show_count")
+  gallerySignalCount   Int      @default(0) @map("gallery_signal_count")
+  eventSignalCount     Int      @default(0) @map("event_signal_count")
+  computedAt           DateTime @default(now()) @map("computed_at")
+
+  artist               Artist   @relation(fields: [artistId], references: [id])
+
+  @@index([window, rank])
+  @@index([artistId, computedAt])
+  @@map("artist_signal_snapshots")
+}
+```
+
+### Relationship Change
+
+This powers roster and representation alerts.
+
+```prisma
+model RelationshipChange {
+  id              BigInt   @id @default(sequence())
+  artistId        BigInt   @map("artist_id")
+  galleryId       Int      @map("gallery_id")
+  changeType      String   @map("change_type") // added | removed | upgraded | downgraded | first_seen | changed_type
+  previousValue   String?  @map("previous_value")
+  currentValue    String?  @map("current_value")
+  sourceUrl       String?  @map("source_url")
+  confidence      Float    @default(0.75)
+  detectedAt      DateTime @default(now()) @map("detected_at")
+  reviewed        Boolean  @default(false)
+
+  artist          Artist   @relation(fields: [artistId], references: [id])
+  gallery         Gallery  @relation(fields: [galleryId], references: [id])
+
+  @@index([artistId, detectedAt])
+  @@index([galleryId, detectedAt])
+  @@index([changeType, detectedAt])
+  @@map("relationship_changes")
+}
+```
+
+### Alert
+
+This turns signals into a B2B workflow.
+
+```prisma
+model Alert {
+  id          BigInt   @id @default(sequence())
+  alertType   String   @map("alert_type") // momentum_spike | roster_change | gallery_status | event_added
+  severity    String   // low | medium | high
+  title       String
+  body        String?
+  entityType  String   @map("entity_type")
+  entityId    String   @map("entity_id")
+  payload     Json?
+  sentAt      DateTime? @map("sent_at")
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  @@index([alertType, createdAt])
+  @@index([entityType, entityId])
+  @@map("alerts")
+}
+```
+
+---
+
+## Product 1: Artist Momentum Radar
+
+### Buyer
+
+- Art advisors
+- Curators
+- Emerging gallery directors
+- Collector research teams
+- Art funds and market analysts
+- Art media and newsletter operators
+
+### Core Promise
+
+"Find artists gaining credible momentum before everyone is talking about them."
+
+### MVP Features
+
+- Top artists by 7d, 30d, and 90d momentum.
+- Artist profile pages with:
+  - Trend score
+  - Rank history
+  - Gallery relationships
+  - CV URL
+  - Instagram URL
+  - Website
+  - Recent exhibitions or openings
+  - Source evidence
+- Filters:
+  - Career stage
+  - Gallery tier
+  - City
+  - Gallery type
+  - Has CV
+  - Has Instagram
+  - Recently verified
+- Export:
+  - CSV
+  - JSON
+  - Saved watchlist
+
+### Scoring Inputs
+
+Start with fields already present or planned:
+
+| Signal | Source | Weight Direction |
+|---|---|---|
+| Gallery count | `galleries_exhibited`, `ArtistGallery` | Positive |
+| Gallery quality/tier | `Gallery.gallery_tier` | Positive |
+| Recent show/event | `data/upcoming-openings.md`, future event table | Strong positive |
+| Instagram followers | `instagram_followers` | Positive, soft-capped |
+| CV presence | `cv_url` | Positive confidence boost |
+| Solo/group show counts | CV parser or Artsy enrichment | Positive |
+| Verified data freshness | `last_verified`, snapshots | Positive confidence boost |
+| Gallery status risk | inactive/unreachable gallery links | Negative confidence adjustment |
+
+### Implementation Steps
+
+1. Normalize artist and gallery CSVs into the database.
+2. Backfill `ArtistGallery` from `galleries_exhibited` and `artist-gallery-consolidated.csv`.
+3. Extend the current scorer in `lib/trending/scorer.js` to include gallery and event signals.
+4. Persist rank history in `ArtistSignalSnapshot`.
+5. Add API endpoints:
+   - `GET /api/v2/b2b/momentum/artists`
+   - `GET /api/v2/b2b/momentum/artists/:id`
+   - `GET /api/v2/b2b/momentum/snapshots/:artist_id`
+6. Build a dashboard page:
+   - `/b2b/momentum`
+   - `/b2b/artists/[id]`
+7. Add saved watchlists after the ranking view is useful.
+
+### MVP Acceptance Criteria
+
+- At least 250 artists ranked.
+- Every ranked artist has a visible reason for the score.
+- Top 50 artists can be exported.
+- Rank history is stored on every computation run.
+- Users can filter by gallery, city, career stage, and verification freshness.
+
+### Product 1 Implementation Checklist
+
+**Frontend-first slice completed May 7, 2026.**
+
+- [x] Create dedicated Momentum Radar route at `/b2b/momentum`.
+- [x] Render dashboard from current local CSV assets before the B2B backend exists.
+- [x] Read `data/artists-consolidated.csv`, `data/galleries-consolidated.csv`, and `data/upcoming-openings.md` in `getStaticProps` when available.
+- [x] Fall back to tracked extracted gallery JSON files and `data/seed-galleries.json` so the PR builds from the default branch.
+- [x] Compute a provisional frontend momentum score for 7d, 30d, and 90d windows.
+- [x] Show ranked artist table with score, career-stage proxy, gallery count, evidence pills, and watchlist UI.
+- [x] Add artist detail panel with signal breakdown, gallery associations, source evidence, and outbound links.
+- [x] Add search, stage filter, and signal filters for CV, Instagram, website, recent event, and top-gallery association.
+- [x] Add CSV export for the currently filtered/ranked view.
+- [x] Add responsive CSS module for the dashboard.
+- [ ] Replace provisional frontend scoring with shared scoring logic from `lib/trending/scorer.js`.
+- [ ] Add `/api/v2/b2b/momentum/artists`.
+- [ ] Add `/api/v2/b2b/momentum/artists/:id`.
+- [ ] Persist score history in `ArtistSignalSnapshot`.
+- [ ] Add real source-evidence records behind every displayed signal.
+- [ ] Add saved watchlists backed by the database.
+- [ ] Add server-side filtering and pagination once the dataset grows beyond the current CSV scale.
+- [ ] Add Playwright screenshot checks for desktop and mobile dashboard states.
+
+---
+
+## Product 2: Roster & Representation Change Alerts
+
+### Buyer
+
+- Art advisors
+- Gallery directors
+- Auction specialists
+- Collectors tracking specific artists
+- Publications tracking market movement
+
+### Core Promise
+
+"Know when an artist's market context changes."
+
+### MVP Features
+
+- Alert feed of relationship changes:
+  - Artist added to gallery roster
+  - Artist removed from gallery roster
+  - New exhibition detected
+  - Representation type changed
+  - Artist appears at stronger gallery or fair
+- Watchlists:
+  - Artists
+  - Galleries
+  - Cities
+  - Career stages
+- Email digest:
+  - Daily
+  - Weekly
+  - High-severity only
+- Manual review queue for low-confidence changes.
+
+### Change Detection Logic
+
+Compare the current scrape/enrichment output to the last known database state:
+
+| Current Observation | Previous State | Change |
+|---|---|---|
+| Artist-gallery link exists now | No link before | `added` |
+| Artist-gallery link missing now | Link existed before | `removed` |
+| Relationship changed from shown to represented | Weaker previous value | `upgraded` |
+| Gallery tier increased | Lower tier before | `upgraded` |
+| Artist appears in fair/opening | No recent event | `event_added` |
+| Source disappeared but no confirmation | Previous source active | `needs_review` |
+
+### Implementation Steps
+
+1. Create `RelationshipChange` and `Alert` tables.
+2. Write a comparison script:
+   - Input: latest artist-gallery CSVs and extracted JSON.
+   - Load current DB relationships.
+   - Detect additions, removals, and changed relationship types.
+   - Store `RelationshipChange` rows.
+3. Add source evidence to each change.
+4. Generate alerts from changes:
+   - High severity: major gallery adds artist, high-momentum artist changes gallery, closure affects roster.
+   - Medium severity: new exhibition, new fair appearance, new CV milestone.
+   - Low severity: weak source or needs manual review.
+5. Add API endpoints:
+   - `GET /api/v2/b2b/alerts`
+   - `GET /api/v2/b2b/alerts/:id`
+   - `POST /api/v2/b2b/alerts/:id/review`
+   - `GET /api/v2/b2b/changes/relationships`
+6. Add dashboard pages:
+   - `/b2b/alerts`
+   - `/b2b/changes`
+7. Add email digest after the alert feed is working.
+
+### MVP Acceptance Criteria
+
+- The system can detect at least three classes of changes: added, removed, changed type.
+- Every alert links to an artist, gallery, and source evidence.
+- Alerts can be filtered by gallery, artist, change type, and confidence.
+- Low-confidence alerts can be marked reviewed.
+- A weekly digest can be generated as HTML or Markdown before email integration.
+
+---
+
+## Product 3: Verified Gallery Intelligence API
+
+### Buyer
+
+- Art SaaS companies
+- Fair organizers
+- Shipping, insurance, framing, and storage vendors
+- Gallery consultants
+- Art PR firms
+- Market data companies
+- Internal sales teams selling into galleries
+
+### Core Promise
+
+"A fresh, verified feed of galleries, artists, relationships, and status changes."
+
+### MVP Features
+
+- Gallery directory API.
+- Gallery status and verification history.
+- Artist roster and relationship API.
+- Artist momentum summary by gallery.
+- Change feed API.
+- CSV export.
+- API keys and basic usage logging.
+
+### API Endpoints
+
+Recommended first endpoints:
+
+```http
+GET /api/v2/b2b/galleries
+GET /api/v2/b2b/galleries/:id
+GET /api/v2/b2b/galleries/:id/artists
+GET /api/v2/b2b/galleries/:id/verification
+GET /api/v2/b2b/artists
+GET /api/v2/b2b/artists/:id
+GET /api/v2/b2b/relationships
+GET /api/v2/b2b/changes
+GET /api/v2/b2b/export/galleries.csv
+GET /api/v2/b2b/export/artists.csv
+```
+
+### Response Shape
+
+Use a consistent envelope:
+
+```json
+{
+  "status": "success",
+  "data": [],
+  "meta": {
+    "total": 0,
+    "limit": 100,
+    "offset": 0,
+    "last_verified": "2026-05-07",
+    "source_count": 0
+  }
+}
+```
+
+### Gallery Object
+
+```json
+{
+  "id": 15,
+  "name": "David Zwirner",
+  "slug": "david-zwirner",
+  "type": "commercial",
+  "locations": ["New York", "London", "Paris", "Hong Kong", "Los Angeles"],
+  "countries": ["USA", "UK", "France", "China", "USA"],
+  "website": "https://www.davidzwirner.com",
+  "instagram": "davidzwirner",
+  "status": "active",
+  "founded_year": 1993,
+  "last_verified": "2026-05-07",
+  "artist_count": 0,
+  "verification": {
+    "http_status": 200,
+    "confidence": 0.95,
+    "source_count": 3
+  }
+}
+```
+
+### Implementation Steps
+
+1. Finish gallery enrichment priority 1:
+   - Investigate the 12 unreachable websites.
+   - Update `status`, `website`, and `last_verified`.
+2. Add gallery Instagram handles and founding years for high-value galleries.
+3. Add `GalleryVerificationSnapshot`.
+4. Modify `scripts/audit_galleries.py` so it can write verification snapshots, not just print an audit.
+5. Build B2B API endpoints using the existing v2 API conventions.
+6. Add API key auth before exposing externally.
+7. Add CSV export.
+8. Add simple usage logs:
+   - API key
+   - endpoint
+   - timestamp
+   - result count
+
+### MVP Acceptance Criteria
+
+- All 52 initial galleries have a current `last_verified` date.
+- The 12 currently unreachable galleries are resolved into active, closed, relocated, or unknown.
+- API returns gallery and relationship data with pagination.
+- CSV export works for galleries and artists.
+- Every commercial field has at least one source or a clear confidence value.
+
+---
+
+## Build Order
+
+### Phase 0: Data Hardening
+
+Goal: make the data trustworthy enough to sell.
+
+Tasks:
+
+- Resolve the 12 unreachable galleries.
+- Add `last_verified` to all gallery rows.
+- Add Instagram handles for galleries.
+- Normalize artist Instagram values into handles or canonical URLs.
+- Backfill artist-gallery links from `galleries_exhibited`.
+- Add source evidence for all manually verified fields.
+
+Exit criteria:
+
+- No blank `last_verified` values for galleries.
+- Every gallery has a status.
+- Every relationship has a relationship type or a default of `shown`.
+
+### Phase 1: Verified Gallery Intelligence API
+
+Build first because it forces clean data contracts.
+
+Tasks:
+
+- Add verification snapshots.
+- Build gallery API endpoints.
+- Build relationship API endpoints.
+- Build CSV exports.
+- Add API key auth.
+
+Exit criteria:
+
+- One external buyer could use the gallery feed without seeing the dashboard.
+
+### Phase 2: Artist Momentum Radar
+
+Build second because it reuses the cleaned entity graph.
+
+Tasks:
+
+- Extend scoring.
+- Persist score snapshots.
+- Build ranked artist endpoint.
+- Build dashboard.
+- Add CSV export.
+
+Exit criteria:
+
+- A user can explain why each top-ranked artist is ranked highly.
+
+### Phase 3: Roster & Representation Change Alerts
+
+Build third because alerts need historical baselines.
+
+Tasks:
+
+- Add relationship change detection.
+- Add alert table.
+- Add alert feed.
+- Add manual review.
+- Generate weekly digest.
+
+Exit criteria:
+
+- The system can produce a useful weekly market movement digest from local data.
+
+### Phase 4: Commercial Packaging
+
+Package the same platform three ways:
+
+| Package | Buyer | Price Shape |
+|---|---|---|
+| Dashboard | Advisors, curators, galleries | Monthly subscription |
+| Alerts | Advisors, auction specialists, collectors | Monthly subscription or per-seat |
+| API/feed | Art SaaS, vendors, research teams | Usage-based or annual data license |
+
+---
+
+## Technical Milestones
+
+### Milestone 1: Data Baseline
+
+- `npm run` or script command for gallery audit writes snapshots.
+- CSV import/upsert script is repeatable.
+- Source evidence table exists.
+- Gallery statuses are fully reviewed.
+
+### Milestone 2: API Baseline
+
+- B2B endpoints exist under `/api/v2/b2b`.
+- Pagination and filtering work.
+- API responses include verification metadata.
+- CSV exports work.
+
+### Milestone 3: Scoring Baseline
+
+- Momentum score uses external and graph signals.
+- Scores are persisted in snapshots.
+- Dashboard shows ranked artists and evidence.
+
+### Milestone 4: Alerts Baseline
+
+- Relationship diff script runs against latest extraction data.
+- Alerts are generated from relationship changes.
+- Review state works.
+- Weekly Markdown digest can be generated.
+
+### Milestone 5: First Sellable Demo
+
+Demo script:
+
+1. Show gallery API response for a verified gallery.
+2. Show an artist ranked in Momentum Radar.
+3. Explain why the artist is trending.
+4. Show gallery relationships and source evidence.
+5. Show one relationship or gallery-status alert.
+6. Export the result as CSV.
+
+---
+
+## Suggested Repo Additions
+
+Recommended new files:
+
+```text
+scripts/import-consolidated-csvs.js
+scripts/write-gallery-verification-snapshots.py
+scripts/detect-relationship-changes.js
+scripts/generate-b2b-alerts.js
+scripts/generate-weekly-market-digest.js
+
+pages/api/v2/b2b/galleries/index.js
+pages/api/v2/b2b/galleries/[id].js
+pages/api/v2/b2b/galleries/[id]/artists.js
+pages/api/v2/b2b/artists/index.js
+pages/api/v2/b2b/artists/[id].js
+pages/api/v2/b2b/momentum/artists.js
+pages/api/v2/b2b/alerts/index.js
+pages/api/v2/b2b/changes/relationships.js
+pages/api/v2/b2b/export/galleries.csv.js
+pages/api/v2/b2b/export/artists.csv.js
+
+pages/b2b/momentum.js
+pages/b2b/alerts.js
+pages/b2b/galleries.js
+pages/b2b/artists/[id].js
+pages/b2b/galleries/[id].js
+```
+
+---
+
+## Ranking The Next 7 By Fit With The First 3
+
+These are ranked by how well they reuse the same data, workflows, buyers, and distribution channels as Artist Momentum Radar, Roster Alerts, and Verified Gallery Intelligence API.
+
+| Fit Rank | Product | Why It Fits | Build Timing |
+|---:|---|---|---|
+| 1 | **Gallery Closure, Relocation & Health Monitor** | Direct extension of gallery verification snapshots and alerting. The current audit already found unreachable gallery websites, so the workflow exists. | Build immediately after Gallery API |
+| 2 | **Gallery Digital Health Benchmark** | Reuses website audits, Instagram enrichment, last verified dates, artist roster clarity, and source confidence. Easy dashboard upsell for galleries and consultants. | Build after gallery verification is stable |
+| 3 | **Art Fair & Exhibition Opportunity Tracker** | Feeds artist momentum and alerts with strong market signals: fair participation, upcoming shows, opening dates, and gallery activity. | Build once events are structured |
+| 4 | **Art Market Data Feed for AI/Search Products** | Mostly a packaging layer on the API. Strong fit with the Verified Gallery Intelligence API, but it needs cleaner docs, usage limits, and licensing. | Build after first API customers |
+| 5 | **Artist Due Diligence & CV Parser** | Improves Momentum Radar quality by extracting solo shows, group shows, institutions, education, collections, and awards. Useful, but parsing takes extra implementation work. | Build after artist ranking has users |
+| 6 | **Collector Outreach Trigger Engine** | Uses momentum and alert signals, but depends on CRM/email integrations and buyer-specific workflows. Best as an integration layer, not an early core product. | Build after alerts prove valuable |
+| 7 | **Artist-Gallery Fit & Prospecting Tool** | Uses the graph, but shifts toward artists/studios as buyers and requires recommendation logic. Good later, but less aligned with the initial B2B intelligence wedge. | Build last among these seven |
+
+### Best Next Add-On
+
+The best fourth product is **Gallery Closure, Relocation & Health Monitor**.
+
+Reason:
+
+- It is already latent in `scripts/audit_galleries.py`.
+- It uses the same `status`, `website`, and `last_verified` fields.
+- It produces alerts naturally.
+- It strengthens the API's freshness story.
+- It is valuable to vendors selling into galleries because bad contact data wastes sales effort.
+
+### Best Fifth Product
+
+The best fifth product is **Gallery Digital Health Benchmark**.
+
+Reason:
+
+- It turns verification data into a score.
+- It gives galleries a reason to care about their own record.
+- It can become a lead-generation wedge for selling dashboard access, enrichment, or consulting.
+
+### Best Product To Delay
+
+Delay **Artist-Gallery Fit & Prospecting Tool**.
+
+Reason:
+
+- It is attractive, but it pulls the product toward artist-facing sales.
+- It needs enough historical relationship data to make recommendations credible.
+- It could be powerful once the first three products produce a clean graph and enough change history.
+
+---
+
+## Practical MVP Scope
+
+The first sellable version should avoid boiling the ocean.
+
+Build only:
+
+- 52 verified galleries.
+- 250 to 500 artists.
+- Relationship graph from current CSVs.
+- One momentum leaderboard.
+- One gallery API.
+- One alert feed.
+- CSV export.
+- Manual review for low-confidence changes.
+
+Do not build yet:
+
+- Full CRM.
+- Marketplace transactions.
+- Public artist discovery marketplace.
+- Automated paid newsletters.
+- Sophisticated valuation model.
+- Recommendation engine.
+
+The first paid product should be a research and intelligence workflow, not a replacement for Artlogic, ArtCloud, Artsy, or a gallery inventory system.
+
+---
+
+## One-Sentence Positioning
+
+ZXY B2B is a verified art-market intelligence layer that tracks artist momentum, gallery roster changes, and gallery data freshness for businesses that need current art-world signals.

--- a/pages/b2b/momentum.js
+++ b/pages/b2b/momentum.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import styles from '../../styles/B2BMomentum.module.css';
@@ -10,6 +10,9 @@ const WINDOWS = [
 ];
 
 const STAGES = ['all', 'Emerging', 'Mid-career', 'Established', 'Researching'];
+const INITIAL_VISIBLE_ARTISTS = 120;
+const VISIBLE_ARTIST_INCREMENT = 120;
+const RANK_LIMIT_PER_WINDOW = 250;
 
 const SIGNAL_FILTERS = [
   { id: 'hasCv', label: 'CV' },
@@ -127,13 +130,37 @@ function parseFollowers(value) {
   return Number(clean) || 0;
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function softScale(value, cap) {
   if (!value || value <= 0) return 0;
   return Math.min(Math.sqrt(value / cap), 1) * 100;
+}
+
+function normalizeSearchText(value) {
+  return String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function normalizeExternalUrl(value, baseUrl = '') {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return '';
+
+  if (/^(https?:|mailto:|tel:)/i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+
+  if (baseUrl) {
+    const normalizedBase = normalizeExternalUrl(baseUrl);
+    try {
+      return new URL(trimmed, normalizedBase).toString();
+    } catch {
+      // Fall through to protocol prefix.
+    }
+  }
+
+  return `https://${trimmed.replace(/^\/+/, '')}`;
 }
 
 function computeScores(signals) {
@@ -186,6 +213,22 @@ function galleryNameFromSlug(value) {
     .filter(Boolean)
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function getRankedArtistUnion(artists, windows, limit) {
+  const artistMap = new Map();
+
+  windows.forEach(window => {
+    [...artists]
+      .sort((a, b) => b.scores[window] - a.scores[window])
+      .slice(0, limit)
+      .forEach(artist => {
+        artistMap.set(artist.id, artist);
+      });
+  });
+
+  return Array.from(artistMap.values())
+    .sort((a, b) => b.scores['30d'] - a.scores['30d']);
 }
 
 function exportRows(rows, window) {
@@ -377,6 +420,7 @@ export default function MomentumRadarPage({ initialArtists, generatedAt, sourceS
   const [signalFilters, setSignalFilters] = useState([]);
   const [selectedId, setSelectedId] = useState(initialArtists[0]?.id || '');
   const [watchedIds, setWatchedIds] = useState([]);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_ARTISTS);
 
   const filteredArtists = useMemo(() => {
     const searchTerm = search.trim().toLowerCase();
@@ -402,6 +446,10 @@ export default function MomentumRadarPage({ initialArtists, generatedAt, sourceS
   }, [initialArtists, search, signalFilters, stage, window]);
 
   const selectedArtist = filteredArtists.find(artist => artist.id === selectedId) || filteredArtists[0] || null;
+  const visibleArtists = useMemo(
+    () => filteredArtists.slice(0, visibleCount),
+    [filteredArtists, visibleCount]
+  );
 
   const stats = useMemo(() => {
     const top = filteredArtists[0];
@@ -433,6 +481,10 @@ export default function MomentumRadarPage({ initialArtists, generatedAt, sourceS
         : [...current, id]
     ));
   }
+
+  useEffect(() => {
+    setVisibleCount(INITIAL_VISIBLE_ARTISTS);
+  }, [search, signalFilters, stage, window]);
 
   return (
     <>
@@ -554,7 +606,7 @@ export default function MomentumRadarPage({ initialArtists, generatedAt, sourceS
             </div>
 
             <div className={styles.artistList}>
-              {filteredArtists.slice(0, 120).map((artist, index) => (
+              {visibleArtists.map((artist, index) => (
                 <ArtistRow
                   key={artist.id}
                   artist={artist}
@@ -569,6 +621,21 @@ export default function MomentumRadarPage({ initialArtists, generatedAt, sourceS
 
               {filteredArtists.length === 0 && (
                 <div className={styles.noResults}>No artists match the current filters.</div>
+              )}
+
+              {filteredArtists.length > visibleArtists.length && (
+                <div className={styles.showMoreWrap}>
+                  <p>
+                    Showing {visibleArtists.length} of {filteredArtists.length} matching artists.
+                  </p>
+                  <button
+                    type="button"
+                    className={styles.showMoreButton}
+                    onClick={() => setVisibleCount(count => count + VISIBLE_ARTIST_INCREMENT)}
+                  >
+                    Show more
+                  </button>
+                </div>
               )}
             </div>
           </div>
@@ -596,11 +663,12 @@ export async function getStaticProps() {
     }
   }
 
-  const [artistCsv, galleryCsv, openingsMd, seedGalleriesJson] = await Promise.all([
+  const [artistCsv, galleryCsv, openingsMd, seedGalleriesJson, topGallerySignalsJson] = await Promise.all([
     readOptional('data/artists-consolidated.csv'),
     readOptional('data/galleries-consolidated.csv'),
     readOptional('data/upcoming-openings.md'),
     readOptional('data/seed-galleries.json'),
+    readOptional('data/top-gallery-signals.json'),
   ]);
 
   const seedGalleries = seedGalleriesJson ? JSON.parse(seedGalleriesJson) : [];
@@ -618,9 +686,14 @@ export async function getStaticProps() {
     const files = await fs.readdir(dataDir).catch(() => []);
     const extractedFiles = files.filter(file => /^extracted-.*\.json$/.test(file));
     const artistMap = new Map();
+    const payloads = await Promise.all(
+      extractedFiles.map(async file => ({
+        file,
+        payload: JSON.parse(await fs.readFile(path.join(dataDir, file), 'utf8')),
+      }))
+    );
 
-    for (const file of extractedFiles) {
-      const payload = JSON.parse(await fs.readFile(path.join(dataDir, file), 'utf8'));
+    for (const { file, payload } of payloads) {
       const fallbackGallery = galleryNameFromSlug(payload.gallery || file.replace(/^extracted-/, '').replace(/\.json$/, ''));
 
       for (const artist of payload.artists || []) {
@@ -656,25 +729,21 @@ export async function getStaticProps() {
   }
 
   const artistRows = artistCsv ? parseCsv(artistCsv) : await loadExtractedArtistRows();
+  const openingsSearchText = ` ${normalizeSearchText(openingsMd)} `;
   const activeGalleries = new Set(
     galleryRows
       .filter(row => row.status === 'active')
       .map(row => row.name.toLowerCase())
   );
-
-  const topGalleryNames = new Set([
-    'art basel',
-    'carpenter\'s workshop gallery',
-    'clearing',
-    'david zwirner',
-    'frieze la',
-    'luhring augustine',
-    'magenta plains',
-    'mana contemporary',
-    'tanya bonakdar gallery',
-    'the armory show',
-    'tiger strikes asteroid',
-  ]);
+  const topGallerySignals = topGallerySignalsJson
+    ? JSON.parse(topGallerySignalsJson)
+    : seedGalleries.filter(gallery => ['major', 'mega'].includes(gallery.tier));
+  const topGalleryNames = new Set(
+    topGallerySignals
+      .flatMap(gallery => [gallery.name, ...(gallery.aliases || [])])
+      .filter(Boolean)
+      .map(name => name.toLowerCase())
+  );
 
   const artists = artistRows
     .filter(row => row.name && row.name.trim())
@@ -685,10 +754,14 @@ export async function getStaticProps() {
       const topGalleryCount = normalizedGalleries.filter(gallery => topGalleryNames.has(gallery)).length;
       const instagram = extractInstagram(row.instagram);
       const instagramFollowers = parseFollowers(row.instagram_followers);
-      const hasWebsite = Boolean(row.website);
-      const hasCv = Boolean(row.cv_url);
+      const website = normalizeExternalUrl(row.website);
+      const cvUrl = normalizeExternalUrl(row.cv_url, website);
+      const hasWebsite = Boolean(website);
+      const hasCv = Boolean(cvUrl);
       const hasInstagram = Boolean(instagram);
-      const recentOpening = Boolean(row._recentOpening) || new RegExp(`\\b${escapeRegExp(row.name.trim())}\\b`, 'i').test(openingsMd);
+      const artistSearchName = normalizeSearchText(row.name.trim());
+      const recentOpening = Boolean(row._recentOpening) ||
+        (artistSearchName && openingsSearchText.includes(` ${artistSearchName} `));
       const confidenceInputs = [
         galleries.length > 0,
         hasWebsite,
@@ -719,9 +792,9 @@ export async function getStaticProps() {
         id: row.id || `artist-${index}`,
         name: row.name.trim(),
         slug: row.slug || '',
-        website: row.website || '',
+        website,
         instagram,
-        cvUrl: row.cv_url || '',
+        cvUrl,
         instagramFollowers,
         galleries,
         galleryCount: galleries.length,
@@ -743,10 +816,13 @@ export async function getStaticProps() {
         },
         scores: computeScores(signals),
       };
-    })
-    .sort((a, b) => b.scores['30d'] - a.scores['30d']);
+    });
 
-  const rankedArtists = artists.slice(0, 250);
+  const rankedArtists = getRankedArtistUnion(
+    artists,
+    WINDOWS.map(item => item.id),
+    RANK_LIMIT_PER_WINDOW
+  );
 
   return {
     props: {

--- a/pages/b2b/momentum.js
+++ b/pages/b2b/momentum.js
@@ -1,0 +1,765 @@
+import { useMemo, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import styles from '../../styles/B2BMomentum.module.css';
+
+const WINDOWS = [
+  { id: '7d', label: '7D' },
+  { id: '30d', label: '30D' },
+  { id: '90d', label: '90D' },
+];
+
+const STAGES = ['all', 'Emerging', 'Mid-career', 'Established', 'Researching'];
+
+const SIGNAL_FILTERS = [
+  { id: 'hasCv', label: 'CV' },
+  { id: 'hasInstagram', label: 'Instagram' },
+  { id: 'hasWebsite', label: 'Website' },
+  { id: 'recentOpening', label: 'Event' },
+  { id: 'topGallery', label: 'Top gallery' },
+];
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let cell = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    const next = text[i + 1];
+
+    if (char === '"' && inQuotes && next === '"') {
+      cell += '"';
+      i += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      row.push(cell);
+      cell = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && next === '\n') i += 1;
+      row.push(cell);
+      if (row.some(value => value.trim() !== '')) rows.push(row);
+      row = [];
+      cell = '';
+      continue;
+    }
+
+    cell += char;
+  }
+
+  if (cell || row.length) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  const [header, ...body] = rows;
+  return body.map(values => {
+    const record = {};
+    header.forEach((key, index) => {
+      record[key] = values[index] || '';
+    });
+    return record;
+  });
+}
+
+function titleCase(value) {
+  return value
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function normalizeGalleryName(value) {
+  return value
+    .replace(/-(NewYork|New York|NY|LA|LosAngeles|Los Angeles|Brussels|Miami|London|Paris|HongKong|Hong Kong|Philadelphia|Chicago|Greenville)$/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseGalleryList(value) {
+  if (!value) return [];
+
+  const names = value
+    .split(/[,;]+/)
+    .map(item => normalizeGalleryName(item))
+    .filter(Boolean)
+    .map(item => {
+      if (item === item.toUpperCase()) return titleCase(item);
+      return item;
+    });
+
+  return Array.from(new Set(names));
+}
+
+function extractInstagram(value) {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+
+  if (trimmed.includes('instagram.com')) {
+    const match = trimmed.match(/instagram\.com\/([A-Za-z0-9._-]+)/);
+    return match?.[1] || '';
+  }
+
+  return trimmed.replace(/^@/, '').replace(/\/$/, '');
+}
+
+function parseFollowers(value) {
+  if (!value) return 0;
+  const clean = String(value).replace(/,/g, '').trim().toLowerCase();
+  if (!clean) return 0;
+
+  if (clean.endsWith('k')) return Math.round(Number(clean.slice(0, -1)) * 1000) || 0;
+  if (clean.endsWith('m')) return Math.round(Number(clean.slice(0, -1)) * 1000000) || 0;
+  return Number(clean) || 0;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function softScale(value, cap) {
+  if (!value || value <= 0) return 0;
+  return Math.min(Math.sqrt(value / cap), 1) * 100;
+}
+
+function computeScores(signals) {
+  const galleryScore = Math.min(signals.galleryCount / 5, 1) * 100;
+  const sourceScore =
+    (signals.hasCv ? 40 : 0) +
+    (signals.hasWebsite ? 30 : 0) +
+    (signals.hasInstagram ? 30 : 0);
+  const socialScore = signals.instagramFollowers
+    ? softScale(signals.instagramFollowers, 100000)
+    : (signals.hasInstagram ? 42 : 0);
+  const eventScore = signals.recentOpening ? 100 : 0;
+  const qualityScore = Math.min((signals.topGalleryCount * 55) + (signals.galleryCount * 7), 100);
+
+  const weights = {
+    '7d': { gallery: 0.24, source: 0.18, social: 0.12, event: 0.34, quality: 0.12 },
+    '30d': { gallery: 0.32, source: 0.22, social: 0.12, event: 0.18, quality: 0.16 },
+    '90d': { gallery: 0.42, source: 0.20, social: 0.10, event: 0.08, quality: 0.20 },
+  };
+
+  return Object.fromEntries(
+    Object.entries(weights).map(([window, w]) => {
+      const raw =
+        galleryScore * w.gallery +
+        sourceScore * w.source +
+        socialScore * w.social +
+        eventScore * w.event +
+        qualityScore * w.quality;
+      const confidenceAdjusted = raw * (0.84 + signals.confidence * 0.16);
+      return [window, Math.round(confidenceAdjusted * 10) / 10];
+    })
+  );
+}
+
+function deriveStage({ galleryCount, topGalleryCount, hasCv, hasWebsite }) {
+  if (topGalleryCount >= 1 && galleryCount >= 3) return 'Established';
+  if (galleryCount >= 3) return 'Mid-career';
+  if (galleryCount >= 1 || hasCv || hasWebsite) return 'Emerging';
+  return 'Researching';
+}
+
+function formatNumber(value) {
+  if (!value) return '0';
+  return Number(value).toLocaleString();
+}
+
+function galleryNameFromSlug(value) {
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function exportRows(rows, window) {
+  const columns = [
+    'rank',
+    'name',
+    'stage',
+    'momentum_score',
+    'gallery_count',
+    'top_gallery_count',
+    'website',
+    'instagram',
+    'cv_url',
+  ];
+
+  const lines = [
+    columns.join(','),
+    ...rows.map((artist, index) => [
+      index + 1,
+      artist.name,
+      artist.stage,
+      artist.scores[window],
+      artist.galleryCount,
+      artist.topGalleryCount,
+      artist.website,
+      artist.instagram ? `https://instagram.com/${artist.instagram}` : '',
+      artist.cvUrl,
+    ].map(value => `"${String(value || '').replace(/"/g, '""')}"`).join(',')),
+  ];
+
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `artist-momentum-${window}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function SignalMeter({ label, value }) {
+  return (
+    <div className={styles.signalMeter}>
+      <div className={styles.signalMeterLabel}>
+        <span>{label}</span>
+        <strong>{Math.round(value)}</strong>
+      </div>
+      <div className={styles.meterTrack}>
+        <div className={styles.meterFill} style={{ width: `${Math.min(value, 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function ArtistInitials({ name }) {
+  const initials = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(part => part[0])
+    .join('')
+    .toUpperCase();
+
+  return <div className={styles.initials}>{initials || 'AR'}</div>;
+}
+
+function EvidencePill({ children, active = true }) {
+  return (
+    <span className={active ? styles.evidencePill : styles.evidencePillMuted}>
+      {children}
+    </span>
+  );
+}
+
+function ArtistRow({ artist, rank, window, selected, onSelect, onToggleWatch, watched }) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={`${styles.artistRow} ${selected ? styles.artistRowSelected : ''}`}
+      onClick={() => onSelect(artist.id)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(artist.id);
+        }
+      }}
+    >
+      <span className={styles.rank}>{rank}</span>
+      <ArtistInitials name={artist.name} />
+      <span className={styles.artistMain}>
+        <span className={styles.artistName}>{artist.name}</span>
+        <span className={styles.artistMeta}>
+          {artist.stage} - {artist.galleryCount} galleries - confidence {artist.confidenceLabel}
+        </span>
+      </span>
+      <span className={styles.rowSignals}>
+        {artist.hasCv && <EvidencePill>CV</EvidencePill>}
+        {artist.hasInstagram && <EvidencePill>IG</EvidencePill>}
+        {artist.recentOpening && <EvidencePill>Event</EvidencePill>}
+        {artist.topGalleryCount > 0 && <EvidencePill>Top gallery</EvidencePill>}
+      </span>
+      <span className={styles.scoreCell}>{artist.scores[window].toFixed(1)}</span>
+      <button
+        type="button"
+        className={`${styles.watchButton} ${watched ? styles.watchButtonActive : ''}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          onToggleWatch(artist.id);
+        }}
+      >
+        {watched ? 'Watching' : 'Watch'}
+      </button>
+    </div>
+  );
+}
+
+function DetailPanel({ artist, window }) {
+  if (!artist) {
+    return (
+      <aside className={styles.detailPanel}>
+        <p className={styles.emptyDetail}>Select an artist to inspect the signal stack.</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className={styles.detailPanel}>
+      <div className={styles.detailHeader}>
+        <ArtistInitials name={artist.name} />
+        <div>
+          <h2>{artist.name}</h2>
+          <p>{artist.stage} - rank signal view</p>
+        </div>
+      </div>
+
+      <div className={styles.detailScore}>
+        <span>{artist.scores[window].toFixed(1)}</span>
+        <p>{window.toUpperCase()} momentum score</p>
+      </div>
+
+      <div className={styles.signalStack}>
+        <SignalMeter label="Gallery graph" value={artist.signalBreakdown.gallery} />
+        <SignalMeter label="Source depth" value={artist.signalBreakdown.source} />
+        <SignalMeter label="Social reach" value={artist.signalBreakdown.social} />
+        <SignalMeter label="Recent event" value={artist.signalBreakdown.event} />
+        <SignalMeter label="Gallery quality" value={artist.signalBreakdown.quality} />
+      </div>
+
+      <div className={styles.detailSection}>
+        <h3>Gallery associations</h3>
+        <div className={styles.galleryList}>
+          {artist.galleries.slice(0, 8).map(gallery => (
+            <span key={gallery}>{gallery}</span>
+          ))}
+          {artist.galleries.length === 0 && <span>No gallery data yet</span>}
+        </div>
+      </div>
+
+      <div className={styles.detailSection}>
+        <h3>Evidence</h3>
+        <div className={styles.evidenceGrid}>
+          <EvidencePill active={artist.hasWebsite}>Website</EvidencePill>
+          <EvidencePill active={artist.hasInstagram}>Instagram</EvidencePill>
+          <EvidencePill active={artist.hasCv}>CV</EvidencePill>
+          <EvidencePill active={artist.recentOpening}>Recent event</EvidencePill>
+          <EvidencePill active={artist.topGalleryCount > 0}>Top gallery</EvidencePill>
+        </div>
+      </div>
+
+      <div className={styles.linkStack}>
+        {artist.website && <a href={artist.website} target="_blank" rel="noopener noreferrer">Website</a>}
+        {artist.instagram && (
+          <a href={`https://instagram.com/${artist.instagram}`} target="_blank" rel="noopener noreferrer">
+            Instagram
+          </a>
+        )}
+        {artist.cvUrl && <a href={artist.cvUrl} target="_blank" rel="noopener noreferrer">CV</a>}
+      </div>
+    </aside>
+  );
+}
+
+export default function MomentumRadarPage({ initialArtists, generatedAt, sourceStats }) {
+  const [window, setWindow] = useState('7d');
+  const [search, setSearch] = useState('');
+  const [stage, setStage] = useState('all');
+  const [signalFilters, setSignalFilters] = useState([]);
+  const [selectedId, setSelectedId] = useState(initialArtists[0]?.id || '');
+  const [watchedIds, setWatchedIds] = useState([]);
+
+  const filteredArtists = useMemo(() => {
+    const searchTerm = search.trim().toLowerCase();
+
+    return initialArtists
+      .filter(artist => {
+        if (stage !== 'all' && artist.stage !== stage) return false;
+        if (searchTerm) {
+          const haystack = `${artist.name} ${artist.galleries.join(' ')}`.toLowerCase();
+          if (!haystack.includes(searchTerm)) return false;
+        }
+
+        return signalFilters.every(filter => {
+          if (filter === 'hasCv') return artist.hasCv;
+          if (filter === 'hasInstagram') return artist.hasInstagram;
+          if (filter === 'hasWebsite') return artist.hasWebsite;
+          if (filter === 'recentOpening') return artist.recentOpening;
+          if (filter === 'topGallery') return artist.topGalleryCount > 0;
+          return true;
+        });
+      })
+      .sort((a, b) => b.scores[window] - a.scores[window]);
+  }, [initialArtists, search, signalFilters, stage, window]);
+
+  const selectedArtist = filteredArtists.find(artist => artist.id === selectedId) || filteredArtists[0] || null;
+
+  const stats = useMemo(() => {
+    const top = filteredArtists[0];
+    const withCv = filteredArtists.filter(artist => artist.hasCv).length;
+    const withInstagram = filteredArtists.filter(artist => artist.hasInstagram).length;
+    const topGallery = filteredArtists.filter(artist => artist.topGalleryCount > 0).length;
+
+    return {
+      ranked: filteredArtists.length,
+      topScore: top ? top.scores[window].toFixed(1) : '0.0',
+      cvCoverage: filteredArtists.length ? Math.round((withCv / filteredArtists.length) * 100) : 0,
+      instagramCoverage: filteredArtists.length ? Math.round((withInstagram / filteredArtists.length) * 100) : 0,
+      topGallery,
+    };
+  }, [filteredArtists, window]);
+
+  function toggleSignalFilter(filter) {
+    setSignalFilters(current => (
+      current.includes(filter)
+        ? current.filter(item => item !== filter)
+        : [...current, filter]
+    ));
+  }
+
+  function toggleWatch(id) {
+    setWatchedIds(current => (
+      current.includes(id)
+        ? current.filter(item => item !== id)
+        : [...current, id]
+    ));
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Artist Momentum Radar - ZXY B2B</title>
+        <meta name="description" content="Ranked artist momentum dashboard for ZXY B2B." />
+      </Head>
+
+      <main className={styles.page}>
+        <header className={styles.topbar}>
+          <Link href="/" className={styles.brand}>ZXY B2B</Link>
+          <nav className={styles.nav}>
+            <Link href="/b2b/momentum">Momentum</Link>
+            <Link href="/trending">Trending</Link>
+            <Link href="/posts/artists">Artists</Link>
+          </nav>
+        </header>
+
+        <section className={styles.workspaceHeader}>
+          <div>
+            <p className={styles.kicker}>Emerging Artist Momentum Radar</p>
+            <h1>Artist momentum</h1>
+            <p className={styles.headerMeta}>
+              {sourceStats.artistCount} ranked artists - {sourceStats.totalArtistCount} source records - {sourceStats.galleryCount} galleries - generated {generatedAt}
+            </p>
+          </div>
+
+          <div className={styles.windowControl} aria-label="Momentum window">
+            {WINDOWS.map(item => (
+              <button
+                type="button"
+                key={item.id}
+                className={window === item.id ? styles.windowActive : ''}
+                onClick={() => setWindow(item.id)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.statGrid} aria-label="Momentum summary">
+          <div className={styles.statTile}>
+            <span>{stats.ranked}</span>
+            <p>ranked artists</p>
+          </div>
+          <div className={styles.statTile}>
+            <span>{stats.topScore}</span>
+            <p>top score</p>
+          </div>
+          <div className={styles.statTile}>
+            <span>{stats.cvCoverage}%</span>
+            <p>CV coverage</p>
+          </div>
+          <div className={styles.statTile}>
+            <span>{stats.instagramCoverage}%</span>
+            <p>Instagram coverage</p>
+          </div>
+          <div className={styles.statTile}>
+            <span>{stats.topGallery}</span>
+            <p>top gallery links</p>
+          </div>
+        </section>
+
+        <section className={styles.controls}>
+          <div className={styles.searchWrap}>
+            <label htmlFor="artist-search">Search</label>
+            <input
+              id="artist-search"
+              type="search"
+              value={search}
+              onChange={event => setSearch(event.target.value)}
+              placeholder="Artist or gallery"
+            />
+          </div>
+
+          <div className={styles.selectWrap}>
+            <label htmlFor="stage-filter">Stage</label>
+            <select id="stage-filter" value={stage} onChange={event => setStage(event.target.value)}>
+              {STAGES.map(item => (
+                <option key={item} value={item}>
+                  {item === 'all' ? 'All stages' : item}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <fieldset className={styles.signalFilters}>
+            <legend>Signals</legend>
+            {SIGNAL_FILTERS.map(filter => (
+              <label key={filter.id}>
+                <input
+                  type="checkbox"
+                  checked={signalFilters.includes(filter.id)}
+                  onChange={() => toggleSignalFilter(filter.id)}
+                />
+                <span>{filter.label}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          <button
+            type="button"
+            className={styles.exportButton}
+            onClick={() => exportRows(filteredArtists, window)}
+          >
+            Export CSV
+          </button>
+        </section>
+
+        <section className={styles.dashboard}>
+          <div className={styles.tablePanel}>
+            <div className={styles.tableHeader}>
+              <span>Rank</span>
+              <span>Artist</span>
+              <span>Signals</span>
+              <span>Score</span>
+              <span>Watchlist</span>
+            </div>
+
+            <div className={styles.artistList}>
+              {filteredArtists.slice(0, 120).map((artist, index) => (
+                <ArtistRow
+                  key={artist.id}
+                  artist={artist}
+                  rank={index + 1}
+                  window={window}
+                  selected={selectedArtist?.id === artist.id}
+                  onSelect={setSelectedId}
+                  onToggleWatch={toggleWatch}
+                  watched={watchedIds.includes(artist.id)}
+                />
+              ))}
+
+              {filteredArtists.length === 0 && (
+                <div className={styles.noResults}>No artists match the current filters.</div>
+              )}
+            </div>
+          </div>
+
+          <DetailPanel artist={selectedArtist} window={window} />
+        </section>
+      </main>
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const fs = await import('fs/promises');
+  const path = await import('path');
+
+  const root = process.cwd();
+  const dataDir = path.join(root, 'data');
+
+  async function readOptional(relativePath) {
+    try {
+      return await fs.readFile(path.join(root, relativePath), 'utf8');
+    } catch (error) {
+      if (error.code === 'ENOENT') return '';
+      throw error;
+    }
+  }
+
+  const [artistCsv, galleryCsv, openingsMd, seedGalleriesJson] = await Promise.all([
+    readOptional('data/artists-consolidated.csv'),
+    readOptional('data/galleries-consolidated.csv'),
+    readOptional('data/upcoming-openings.md'),
+    readOptional('data/seed-galleries.json'),
+  ]);
+
+  const seedGalleries = seedGalleriesJson ? JSON.parse(seedGalleriesJson) : [];
+  const galleryRows = galleryCsv
+    ? parseCsv(galleryCsv)
+    : seedGalleries.map(gallery => ({
+      name: gallery.name,
+      slug: gallery.slug,
+      website: gallery.website,
+      status: 'active',
+      type: gallery.tier || gallery.segment || 'gallery',
+    }));
+
+  async function loadExtractedArtistRows() {
+    const files = await fs.readdir(dataDir).catch(() => []);
+    const extractedFiles = files.filter(file => /^extracted-.*\.json$/.test(file));
+    const artistMap = new Map();
+
+    for (const file of extractedFiles) {
+      const payload = JSON.parse(await fs.readFile(path.join(dataDir, file), 'utf8'));
+      const fallbackGallery = galleryNameFromSlug(payload.gallery || file.replace(/^extracted-/, '').replace(/\.json$/, ''));
+
+      for (const artist of payload.artists || []) {
+        if (!artist.name) continue;
+
+        const key = artist.name.trim().toLowerCase();
+        const existing = artistMap.get(key) || {
+          name: artist.name.trim(),
+          website: '',
+          instagram: '',
+          instagram_followers: '',
+          cv_url: '',
+          galleries_exhibited: '',
+          _recentOpening: false,
+        };
+
+        const galleries = new Set(parseGalleryList(existing.galleries_exhibited));
+        const representedBy = artist.represented_by?.length ? artist.represented_by : [fallbackGallery];
+        representedBy.forEach(gallery => {
+          if (gallery) galleries.add(gallery);
+        });
+
+        existing.website = existing.website || artist.website || '';
+        existing.instagram = existing.instagram || artist.instagram || '';
+        existing.galleries_exhibited = Array.from(galleries).join(', ');
+        existing._recentOpening = existing._recentOpening || (artist.shows || []).some(show => Number(show.year) >= 2026);
+
+        artistMap.set(key, existing);
+      }
+    }
+
+    return Array.from(artistMap.values());
+  }
+
+  const artistRows = artistCsv ? parseCsv(artistCsv) : await loadExtractedArtistRows();
+  const activeGalleries = new Set(
+    galleryRows
+      .filter(row => row.status === 'active')
+      .map(row => row.name.toLowerCase())
+  );
+
+  const topGalleryNames = new Set([
+    'art basel',
+    'carpenter\'s workshop gallery',
+    'clearing',
+    'david zwirner',
+    'frieze la',
+    'luhring augustine',
+    'magenta plains',
+    'mana contemporary',
+    'tanya bonakdar gallery',
+    'the armory show',
+    'tiger strikes asteroid',
+  ]);
+
+  const artists = artistRows
+    .filter(row => row.name && row.name.trim())
+    .map((row, index) => {
+      const galleries = parseGalleryList(row.galleries_exhibited);
+      const normalizedGalleries = galleries.map(gallery => gallery.toLowerCase());
+      const activeGalleryCount = normalizedGalleries.filter(gallery => activeGalleries.has(gallery)).length;
+      const topGalleryCount = normalizedGalleries.filter(gallery => topGalleryNames.has(gallery)).length;
+      const instagram = extractInstagram(row.instagram);
+      const instagramFollowers = parseFollowers(row.instagram_followers);
+      const hasWebsite = Boolean(row.website);
+      const hasCv = Boolean(row.cv_url);
+      const hasInstagram = Boolean(instagram);
+      const recentOpening = Boolean(row._recentOpening) || new RegExp(`\\b${escapeRegExp(row.name.trim())}\\b`, 'i').test(openingsMd);
+      const confidenceInputs = [
+        galleries.length > 0,
+        hasWebsite,
+        hasCv,
+        hasInstagram,
+        activeGalleryCount > 0,
+      ];
+      const confidence = confidenceInputs.filter(Boolean).length / confidenceInputs.length;
+
+      const signals = {
+        galleryCount: galleries.length,
+        topGalleryCount,
+        hasWebsite,
+        hasCv,
+        hasInstagram,
+        instagramFollowers,
+        recentOpening,
+        confidence,
+      };
+
+      const gallerySignal = Math.min(galleries.length / 5, 1) * 100;
+      const sourceSignal = (hasCv ? 40 : 0) + (hasWebsite ? 30 : 0) + (hasInstagram ? 30 : 0);
+      const socialSignal = instagramFollowers ? softScale(instagramFollowers, 100000) : (hasInstagram ? 42 : 0);
+      const eventSignal = recentOpening ? 100 : 0;
+      const qualitySignal = Math.min((topGalleryCount * 55) + (galleries.length * 7), 100);
+
+      return {
+        id: row.id || `artist-${index}`,
+        name: row.name.trim(),
+        slug: row.slug || '',
+        website: row.website || '',
+        instagram,
+        cvUrl: row.cv_url || '',
+        instagramFollowers,
+        galleries,
+        galleryCount: galleries.length,
+        activeGalleryCount,
+        topGalleryCount,
+        hasWebsite,
+        hasCv,
+        hasInstagram,
+        recentOpening,
+        confidence,
+        confidenceLabel: `${Math.round(confidence * 100)}%`,
+        stage: deriveStage({ galleryCount: galleries.length, topGalleryCount, hasCv, hasWebsite }),
+        signalBreakdown: {
+          gallery: Math.round(gallerySignal),
+          source: Math.round(sourceSignal),
+          social: Math.round(socialSignal),
+          event: Math.round(eventSignal),
+          quality: Math.round(qualitySignal),
+        },
+        scores: computeScores(signals),
+      };
+    })
+    .sort((a, b) => b.scores['30d'] - a.scores['30d']);
+
+  const rankedArtists = artists.slice(0, 250);
+
+  return {
+    props: {
+      initialArtists: rankedArtists,
+      generatedAt: new Date().toISOString().slice(0, 10),
+      sourceStats: {
+        artistCount: rankedArtists.length,
+        totalArtistCount: artists.length,
+        galleryCount: galleryRows.length,
+        activeGalleryCount: activeGalleries.size,
+        withCv: rankedArtists.filter(artist => artist.hasCv).length,
+        withInstagram: rankedArtists.filter(artist => artist.hasInstagram).length,
+      },
+    },
+  };
+}

--- a/styles/B2BMomentum.module.css
+++ b/styles/B2BMomentum.module.css
@@ -575,6 +575,39 @@
   text-align: center;
 }
 
+.showMoreWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 18px;
+  border-top: 1px solid #eef2f6;
+  background: #fbfcfd;
+}
+
+.showMoreWrap p {
+  margin: 0;
+  color: #667085;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.showMoreButton {
+  min-width: 116px;
+  height: 36px;
+  border: 1px solid #2f80ed;
+  border-radius: 8px;
+  background: #eef6ff;
+  color: #175cd3;
+  font-size: 12px;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.showMoreButton:hover {
+  background: #dcecff;
+}
+
 @media (max-width: 1180px) {
   .controls {
     grid-template-columns: 1fr 180px;
@@ -708,5 +741,10 @@
 
   .linkStack {
     grid-template-columns: 1fr;
+  }
+
+  .showMoreWrap {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/styles/B2BMomentum.module.css
+++ b/styles/B2BMomentum.module.css
@@ -1,0 +1,712 @@
+.page {
+  min-height: 100vh;
+  background: #f6f7f8;
+  color: #17202a;
+  padding-bottom: 48px;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  height: 64px;
+  padding: 0 32px;
+  border-bottom: 1px solid #dde3ea;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(12px);
+}
+
+.brand {
+  color: #111827;
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-decoration: none;
+}
+
+.brand:hover,
+.nav a:hover,
+.linkStack a:hover {
+  text-decoration: none;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.nav a {
+  color: #536171;
+  text-decoration: none;
+}
+
+.nav a:first-child {
+  color: #b42318;
+}
+
+.workspaceHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 36px 32px 20px;
+}
+
+.kicker {
+  margin: 0 0 6px;
+  color: #8a3a25;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.workspaceHeader h1 {
+  margin: 0;
+  color: #111827;
+  font-size: 34px;
+  line-height: 1.08;
+  letter-spacing: 0;
+}
+
+.headerMeta {
+  margin: 8px 0 0;
+  color: #667085;
+  font-size: 14px;
+}
+
+.windowControl {
+  display: grid;
+  grid-template-columns: repeat(3, 56px);
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.windowControl button {
+  height: 36px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #667085;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.windowControl .windowActive {
+  background: #1f2937;
+  color: #ffffff;
+}
+
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 32px 16px;
+}
+
+.statTile {
+  min-height: 92px;
+  padding: 18px;
+  border: 1px solid #dde3ea;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.statTile span {
+  display: block;
+  color: #111827;
+  font-size: 28px;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.statTile p {
+  margin: 8px 0 0;
+  color: #667085;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 180px minmax(360px, 1.4fr) 128px;
+  gap: 12px;
+  align-items: end;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 32px 20px;
+}
+
+.searchWrap,
+.selectWrap {
+  display: grid;
+  gap: 6px;
+}
+
+.searchWrap label,
+.selectWrap label,
+.signalFilters legend {
+  color: #536171;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.searchWrap input,
+.selectWrap select {
+  width: 100%;
+  height: 42px;
+  border: 1px solid #cfd8e3;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #17202a;
+  font-size: 14px;
+  outline: none;
+}
+
+.searchWrap input {
+  padding: 0 12px;
+}
+
+.selectWrap select {
+  padding: 0 10px;
+}
+
+.searchWrap input:focus,
+.selectWrap select:focus {
+  border-color: #2f80ed;
+  box-shadow: 0 0 0 3px rgba(47, 128, 237, 0.16);
+}
+
+.signalFilters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.signalFilters legend {
+  float: left;
+  width: 100%;
+  margin-bottom: 6px;
+}
+
+.signalFilters label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #44505f;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.signalFilters input {
+  width: 14px;
+  height: 14px;
+  accent-color: #0f766e;
+}
+
+.exportButton {
+  height: 42px;
+  border: 1px solid #99261b;
+  border-radius: 8px;
+  background: #b42318;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.exportButton:hover {
+  background: #99261b;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 16px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.tablePanel,
+.detailPanel {
+  border: 1px solid #dde3ea;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.tablePanel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.tableHeader {
+  display: grid;
+  grid-template-columns: 58px minmax(260px, 1fr) minmax(210px, 0.8fr) 86px 104px;
+  gap: 12px;
+  align-items: center;
+  height: 46px;
+  padding: 0 14px;
+  border-bottom: 1px solid #dde3ea;
+  background: #fbfcfd;
+  color: #667085;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.artistList {
+  max-height: calc(100vh - 348px);
+  min-height: 420px;
+  overflow: auto;
+}
+
+.artistRow {
+  display: grid;
+  grid-template-columns: 42px 44px minmax(220px, 1fr) minmax(210px, 0.8fr) 72px 104px;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  min-height: 76px;
+  padding: 10px 14px;
+  border: 0;
+  border-bottom: 1px solid #eef2f6;
+  background: #ffffff;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.artistRow:hover {
+  background: #fbfcfd;
+}
+
+.artistRow:focus-visible {
+  outline: 3px solid rgba(47, 128, 237, 0.28);
+  outline-offset: -3px;
+}
+
+.artistRowSelected {
+  background: #f0f7ff;
+  box-shadow: inset 3px 0 0 #2f80ed;
+}
+
+.rank {
+  color: #8b98a7;
+  font-size: 13px;
+  font-weight: 850;
+  text-align: right;
+}
+
+.initials {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid #d5dee8;
+  border-radius: 8px;
+  background: #e9f6f3;
+  color: #0f5f59;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.artistMain {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.artistName {
+  overflow: hidden;
+  color: #17202a;
+  font-size: 15px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artistMeta {
+  overflow: hidden;
+  color: #667085;
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rowSignals,
+.evidenceGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.evidencePill,
+.evidencePillMuted {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.evidencePill {
+  border: 1px solid #badbcc;
+  background: #ecfdf3;
+  color: #087443;
+}
+
+.evidencePillMuted {
+  border: 1px solid #e4e7ec;
+  background: #f7f8fa;
+  color: #98a2b3;
+}
+
+.scoreCell {
+  color: #111827;
+  font-size: 20px;
+  font-weight: 900;
+  text-align: right;
+}
+
+.watchButton {
+  display: inline-grid;
+  place-items: center;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #536171;
+  font-size: 12px;
+  font-weight: 850;
+  text-align: center;
+  cursor: pointer;
+}
+
+.watchButtonActive {
+  border-color: #14532d;
+  background: #14532d;
+  color: #ffffff;
+}
+
+.detailPanel {
+  position: sticky;
+  top: 84px;
+  align-self: start;
+  padding: 18px;
+}
+
+.detailHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.detailHeader h2 {
+  margin: 0;
+  color: #111827;
+  font-size: 20px;
+  line-height: 1.15;
+}
+
+.detailHeader p {
+  margin: 4px 0 0;
+  color: #667085;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.detailScore {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  align-items: center;
+  gap: 14px;
+  min-height: 86px;
+  margin: 18px 0;
+  padding: 14px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #fbfcfd;
+}
+
+.detailScore span {
+  color: #111827;
+  font-size: 34px;
+  font-weight: 950;
+  line-height: 1;
+}
+
+.detailScore p {
+  margin: 0;
+  color: #667085;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.signalStack {
+  display: grid;
+  gap: 12px;
+}
+
+.signalMeter {
+  display: grid;
+  gap: 6px;
+}
+
+.signalMeterLabel {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #44505f;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.signalMeterLabel strong {
+  color: #111827;
+}
+
+.meterTrack {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef5;
+}
+
+.meterFill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #0f766e, #2f80ed);
+}
+
+.detailSection {
+  margin-top: 20px;
+}
+
+.detailSection h3 {
+  margin: 0 0 8px;
+  color: #344054;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.galleryList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.galleryList span {
+  min-height: 26px;
+  padding: 4px 8px;
+  border: 1px solid #e4e7ec;
+  border-radius: 6px;
+  background: #f7f8fa;
+  color: #44505f;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.linkStack {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.linkStack a {
+  display: grid;
+  place-items: center;
+  min-height: 36px;
+  border: 1px solid #2f80ed;
+  border-radius: 8px;
+  background: #eef6ff;
+  color: #175cd3;
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.emptyDetail,
+.noResults {
+  margin: 0;
+  color: #667085;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.noResults {
+  padding: 42px 18px;
+  text-align: center;
+}
+
+@media (max-width: 1180px) {
+  .controls {
+    grid-template-columns: 1fr 180px;
+  }
+
+  .signalFilters,
+  .exportButton {
+    grid-column: span 2;
+  }
+
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .detailPanel {
+    position: static;
+  }
+
+  .artistList {
+    max-height: none;
+  }
+}
+
+@media (max-width: 860px) {
+  .topbar,
+  .workspaceHeader,
+  .statGrid,
+  .controls,
+  .dashboard {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .topbar {
+    height: auto;
+    min-height: 64px;
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 8px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+
+  .nav {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .workspaceHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .workspaceHeader h1 {
+    font-size: 28px;
+  }
+
+  .windowControl {
+    width: 100%;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .controls {
+    grid-template-columns: 1fr;
+  }
+
+  .signalFilters,
+  .exportButton {
+    grid-column: auto;
+  }
+
+  .signalFilters {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .tableHeader {
+    display: none;
+  }
+
+  .artistRow {
+    grid-template-columns: 36px 42px minmax(0, 1fr) 68px;
+    min-height: 94px;
+  }
+
+  .rowSignals {
+    grid-column: 3 / -1;
+  }
+
+  .watchButton {
+    grid-column: 4;
+  }
+
+  .scoreCell {
+    grid-column: 4;
+    grid-row: 1;
+  }
+}
+
+@media (max-width: 520px) {
+  .statGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .artistRow {
+    grid-template-columns: 32px minmax(0, 1fr) 62px;
+    gap: 8px;
+  }
+
+  .artistRow .initials {
+    display: none;
+  }
+
+  .artistMain {
+    grid-column: 2;
+  }
+
+  .rowSignals {
+    grid-column: 2 / -1;
+  }
+
+  .watchButton {
+    grid-column: 2 / -1;
+    justify-self: stretch;
+  }
+
+  .linkStack {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated /b2b/momentum frontend for the Emerging Artist Momentum Radar
- compute provisional 7d/30d/90d artist momentum rankings from consolidated CSVs when present, with extracted JSON fallback for the default branch
- add filters, watchlist UI, detail panel, signal breakdown, CSV export, and responsive styling
- add the B2B spinout implementation guide with a Product 1 completion checklist

## Verification
- npm run build

## Notes
- docs/generic-b2b.md is untracked locally and intentionally not included in this PR.