### PR TITLE
Fix Social PR frontend Tailwind verification

### DIFF
--- a/social-pr-autopilot/Makefile
+++ b/social-pr-autopilot/Makefile
@@ -4,7 +4,7 @@ backend:
 	cd backend && uvicorn app.main:app --reload --port 8102
 
 frontend:
-	cd frontend && npm run dev -- --port 3102
+	cd frontend && npm run dev:local
 
 test-backend:
 	cd backend && pytest

--- a/social-pr-autopilot/README.md
+++ b/social-pr-autopilot/README.md
@@ -47,10 +47,12 @@ AI_PROVIDER=mistral uvicorn app.main:app --reload --port 8102
 ```bash
 cd social-pr-autopilot/frontend
 npm install
-NEXT_PUBLIC_API_BASE=http://localhost:8102 npm run dev -- --port 3102
+npm run dev:local
 ```
 
 Open `http://localhost:3102`.
+
+Run this from `social-pr-autopilot/frontend`, not the repo root. The repo root is a separate `zxy3` Next app, so its Vercel preview is not the Social PR Autopilot frontend unless Vercel is configured with this nested frontend as the project root.
 
 ## GCP Migration Shape
 

--- a/social-pr-autopilot/README.md
+++ b/social-pr-autopilot/README.md
@@ -80,3 +80,5 @@ cd social-pr-autopilot/tests
 npm install
 npm test
 ```
+
+Playwright uses `3112` so tests do not collide with the local dashboard on `3102`.

--- a/social-pr-autopilot/backend/app/ai_providers.py
+++ b/social-pr-autopilot/backend/app/ai_providers.py
@@ -3,9 +3,8 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, NoReturn
 
-import httpx
-
 from .config import ai_provider_preference, config_status, deploy_target, env_source, env_value
+from .http_clients import ai_client
 from .runtime import APP_NAME, record_event
 
 
@@ -55,30 +54,28 @@ async def generate_text(prompt: str, *, purpose: str) -> str:
 async def _gemini(prompt: str, api_key: str) -> str:
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{_gemini_model()}:generateContent"
     payload: dict[str, Any] = {"contents": [{"parts": [{"text": prompt}]}]}
-    async with httpx.AsyncClient(timeout=45) as client:
-        response = await client.post(url, json=payload, headers={"x-goog-api-key": api_key})
-        response.raise_for_status()
-        try:
-            content = response.json()["candidates"][0]["content"]["parts"][0]["text"]
-        except (KeyError, IndexError, TypeError, ValueError) as exc:
-            _raise_provider_parse_error("gemini", response.text, exc)
-        return str(content)
+    response = await ai_client().post(url, json=payload, headers={"x-goog-api-key": api_key})
+    response.raise_for_status()
+    try:
+        content = response.json()["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        _raise_provider_parse_error("gemini", response.text, exc)
+    return str(content)
 
 
 async def _mistral(prompt: str, api_key: str) -> str:
     payload = {"model": _mistral_model(), "messages": [{"role": "user", "content": prompt}]}
-    async with httpx.AsyncClient(timeout=45) as client:
-        response = await client.post(
-            "https://api.mistral.ai/v1/chat/completions",
-            json=payload,
-            headers={"Authorization": f"Bearer {api_key}"},
-        )
-        response.raise_for_status()
-        try:
-            content = response.json()["choices"][0]["message"]["content"]
-        except (KeyError, IndexError, TypeError, ValueError) as exc:
-            _raise_provider_parse_error("mistral", response.text, exc)
-        return str(content)
+    response = await ai_client().post(
+        "https://api.mistral.ai/v1/chat/completions",
+        json=payload,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    response.raise_for_status()
+    try:
+        content = response.json()["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        _raise_provider_parse_error("mistral", response.text, exc)
+    return str(content)
 
 
 async def _with_retries(call: Callable[[], Awaitable[str]], provider: str) -> str:

--- a/social-pr-autopilot/backend/app/channel_adapters.py
+++ b/social-pr-autopilot/backend/app/channel_adapters.py
@@ -1,12 +1,17 @@
+import base64
 import json
 import os
+import time
 from datetime import datetime, timezone
 from typing import Any
 
 import httpx
 
+from .http_clients import channel_client
 from .models import ChannelAdapterStatus, PublishRequest, PublishResult
 from .runtime import check_rate_limit, create_publish_log, record_event, update_publish_log
+
+BLUESKY_SESSION: dict[str, Any] = {}
 
 
 def adapter_statuses() -> list[ChannelAdapterStatus]:
@@ -156,13 +161,12 @@ async def _publish_telegram(payload: PublishRequest) -> str:
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if not token or not chat_id:
         raise RuntimeError("Telegram credentials missing: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required")
-    async with httpx.AsyncClient(timeout=30) as client:
-        response = await client.post(
-            f"https://api.telegram.org/bot{token}/sendMessage",
-            json={"chat_id": chat_id, "text": payload.text, "disable_web_page_preview": False},
-        )
-        response.raise_for_status()
-        data = response.json()
+    response = await channel_client().post(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        json={"chat_id": chat_id, "text": payload.text, "disable_web_page_preview": False},
+    )
+    response.raise_for_status()
+    data = response.json()
     return str(data.get("result", {}).get("message_id", "telegram-message"))
 
 
@@ -171,33 +175,85 @@ async def _publish_bluesky(payload: PublishRequest) -> str:
     password = os.getenv("BLUESKY_APP_PASSWORD")
     if not handle or not password:
         raise RuntimeError("Bluesky credentials missing: BLUESKY_HANDLE and BLUESKY_APP_PASSWORD are required")
-    async with httpx.AsyncClient(timeout=30) as client:
-        session_response = await client.post(
-            "https://bsky.social/xrpc/com.atproto.server.createSession",
-            json={"identifier": handle, "password": password},
-        )
-        session_response.raise_for_status()
-        session = session_response.json()
-        access_jwt = session.get("accessJwt")
-        repo = session.get("did")
-        if not access_jwt or not repo:
-            raise ValueError("Invalid Bluesky session response: missing accessJwt or did")
-        record_response = await client.post(
-            "https://bsky.social/xrpc/com.atproto.repo.createRecord",
-            headers={"Authorization": f"Bearer {access_jwt}"},
-            json={
-                "repo": repo,
-                "collection": "app.bsky.feed.post",
-                "record": {
-                    "$type": "app.bsky.feed.post",
-                    "text": payload.text[:300],
-                    "createdAt": _now_iso(),
-                },
-            },
-        )
-        record_response.raise_for_status()
-        record = record_response.json()
+    access_jwt, repo = await _bluesky_session(handle, password)
+    try:
+        record = await _create_bluesky_record(repo, access_jwt, payload.text)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 401:
+            raise
+        BLUESKY_SESSION.clear()
+        access_jwt, repo = await _bluesky_session(handle, password)
+        record = await _create_bluesky_record(repo, access_jwt, payload.text)
     return str(record.get("uri", "bluesky-post"))
+
+
+async def _bluesky_session(handle: str, password: str) -> tuple[str, str]:
+    if _cached_bluesky_session_valid(handle):
+        return BLUESKY_SESSION["access_jwt"], BLUESKY_SESSION["did"]
+
+    session_response = await channel_client().post(
+        "https://bsky.social/xrpc/com.atproto.server.createSession",
+        json={"identifier": handle, "password": password},
+    )
+    session_response.raise_for_status()
+    session = session_response.json()
+    access_jwt = session.get("accessJwt")
+    did = session.get("did")
+    if not access_jwt or not did:
+        raise ValueError("Invalid Bluesky session response: missing accessJwt or did")
+
+    BLUESKY_SESSION.clear()
+    BLUESKY_SESSION.update({
+        "handle": handle,
+        "access_jwt": access_jwt,
+        "did": did,
+        "expires_at": _jwt_expires_at(access_jwt),
+    })
+    return access_jwt, did
+
+
+def _cached_bluesky_session_valid(handle: str) -> bool:
+    expires_at = float(BLUESKY_SESSION.get("expires_at", 0))
+    return (
+        BLUESKY_SESSION.get("handle") == handle
+        and bool(BLUESKY_SESSION.get("access_jwt"))
+        and bool(BLUESKY_SESSION.get("did"))
+        and expires_at > time.time() + 60
+    )
+
+
+def _jwt_expires_at(token: str) -> float:
+    try:
+        payload_segment = token.split(".")[1]
+        padded = payload_segment + "=" * (-len(payload_segment) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+        exp = payload.get("exp")
+        if isinstance(exp, (int, float)):
+            return float(exp)
+    except (IndexError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+    return time.time() + 3000
+
+
+async def _create_bluesky_record(repo: str, access_jwt: str, text: str) -> dict[str, Any]:
+    record_response = await channel_client().post(
+        "https://bsky.social/xrpc/com.atproto.repo.createRecord",
+        headers={"Authorization": f"Bearer {access_jwt}"},
+        json={
+            "repo": repo,
+            "collection": "app.bsky.feed.post",
+            "record": {
+                "$type": "app.bsky.feed.post",
+                "text": text[:300],
+                "createdAt": _now_iso(),
+            },
+        },
+    )
+    record_response.raise_for_status()
+    record = record_response.json()
+    if not isinstance(record, dict):
+        raise ValueError("Invalid Bluesky record response")
+    return record
 
 
 def _next_action_for_error(channel: str, error: str, diagnostics: dict[str, Any]) -> str:
@@ -261,4 +317,4 @@ def _rate_limit_label(channel: str) -> str:
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/social-pr-autopilot/backend/app/http_clients.py
+++ b/social-pr-autopilot/backend/app/http_clients.py
@@ -1,0 +1,29 @@
+import httpx
+
+
+_AI_CLIENT: httpx.AsyncClient | None = None
+_CHANNEL_CLIENT: httpx.AsyncClient | None = None
+
+
+def ai_client() -> httpx.AsyncClient:
+    global _AI_CLIENT
+    if _AI_CLIENT is None or _AI_CLIENT.is_closed:
+        _AI_CLIENT = httpx.AsyncClient(timeout=45)
+    return _AI_CLIENT
+
+
+def channel_client() -> httpx.AsyncClient:
+    global _CHANNEL_CLIENT
+    if _CHANNEL_CLIENT is None or _CHANNEL_CLIENT.is_closed:
+        _CHANNEL_CLIENT = httpx.AsyncClient(timeout=30)
+    return _CHANNEL_CLIENT
+
+
+async def close_http_clients() -> None:
+    global _AI_CLIENT, _CHANNEL_CLIENT
+    if _AI_CLIENT is not None and not _AI_CLIENT.is_closed:
+        await _AI_CLIENT.aclose()
+    if _CHANNEL_CLIENT is not None and not _CHANNEL_CLIENT.is_closed:
+        await _CHANNEL_CLIENT.aclose()
+    _AI_CLIENT = None
+    _CHANNEL_CLIENT = None

--- a/social-pr-autopilot/backend/app/main.py
+++ b/social-pr-autopilot/backend/app/main.py
@@ -1,12 +1,14 @@
-import uuid
 import logging
 import time
+import uuid
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from .ai_providers import generate_text, provider_status
 from .channel_adapters import adapter_diagnostics, adapter_statuses, publish, retry_publish
+from .http_clients import close_http_clients
 from .logging_config import configure_logging
 from .models import CampaignPack, CampaignRequest, ChannelAdapterStatus, PublishRequest, PublishResult
 from .runtime import APP_NAME, allowed_origins, debug_snapshot, finish_run, get_publish_log, get_run, list_publish_logs, list_runs, record_event, start_run, uptime_seconds
@@ -14,7 +16,17 @@ from .runtime import APP_NAME, allowed_origins, debug_snapshot, finish_run, get_
 
 configure_logging(APP_NAME)
 logger = logging.getLogger(APP_NAME)
-app = FastAPI(title="Social PR Autopilot")
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    try:
+        yield
+    finally:
+        await close_http_clients()
+
+
+app = FastAPI(title="Social PR Autopilot", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins(),

--- a/social-pr-autopilot/backend/tests/test_social_pr_api_contract.py
+++ b/social-pr-autopilot/backend/tests/test_social_pr_api_contract.py
@@ -120,3 +120,9 @@ def test_instagram_scheduling_export() -> None:
     assert payload["status"] == "exported"
     assert payload["payload"]["format"] == "scheduling_export"
     assert payload["next_action"]
+
+
+def test_bluesky_timestamp_uses_z_suffix() -> None:
+    from app.channel_adapters import _now_iso
+
+    assert _now_iso().endswith("Z")

--- a/social-pr-autopilot/docs/upgrade-summary.md
+++ b/social-pr-autopilot/docs/upgrade-summary.md
@@ -70,7 +70,7 @@ Validated locally:
 - Mistral live smoke test succeeds.
 - `/api/campaign` generates campaign content through Mistral.
 - Frontend production build passes.
-- Playwright dashboard smoke test passes.
+- Playwright dashboard smoke test passes and verifies Tailwind-computed styles on the body, heading, and primary action.
 
 ## GCP Migration Shape
 

--- a/social-pr-autopilot/frontend/package.json
+++ b/social-pr-autopilot/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:local": "NEXT_PUBLIC_API_BASE=http://localhost:8102 next dev --hostname 127.0.0.1 --port 3102",
+    "dev:test": "NEXT_PUBLIC_API_BASE=http://localhost:8102 next dev --hostname 127.0.0.1 --port 3112",
     "build": "next build",
     "start": "next start",
     "start:local": "NEXT_PUBLIC_API_BASE=http://localhost:8102 next start --hostname 127.0.0.1 --port 3102"

--- a/social-pr-autopilot/frontend/package.json
+++ b/social-pr-autopilot/frontend/package.json
@@ -3,8 +3,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "NEXT_PUBLIC_API_BASE=http://localhost:8102 next dev --hostname 127.0.0.1 --port 3102",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "start:local": "NEXT_PUBLIC_API_BASE=http://localhost:8102 next start --hostname 127.0.0.1 --port 3102"
   },
   "dependencies": {
     "next": "^14.2.3",

--- a/social-pr-autopilot/tests/playwright.config.ts
+++ b/social-pr-autopilot/tests/playwright.config.ts
@@ -2,9 +2,9 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: ".",
-  use: { baseURL: "http://127.0.0.1:3102" },
+  use: { baseURL: "http://127.0.0.1:3112" },
   webServer: {
-    command: "npm run dev:local",
+    command: "npm run dev:test",
     cwd: "../frontend",
     reuseExistingServer: true,
     timeout: 120000,

--- a/social-pr-autopilot/tests/playwright.config.ts
+++ b/social-pr-autopilot/tests/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: ".",
   use: { baseURL: "http://127.0.0.1:3102" },
   webServer: {
-    command: "npm run dev -- --port 3102",
+    command: "npm run dev:local",
     cwd: "../frontend",
     reuseExistingServer: true,
     timeout: 120000,

--- a/social-pr-autopilot/tests/social-pr.spec.ts
+++ b/social-pr-autopilot/tests/social-pr.spec.ts
@@ -8,4 +8,8 @@ test("renders the Social PR dashboard", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Instagram export" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Telegram dry-run" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Bluesky dry-run" })).toBeVisible();
+
+  await expect(page.locator("body")).toHaveCSS("background-color", "rgb(255, 247, 237)");
+  await expect(page.getByRole("heading", { name: "Social PR Autopilot" })).toHaveCSS("font-weight", "900");
+  await expect(page.getByRole("button", { name: "Generate Campaign" })).toHaveCSS("background-color", "rgb(194, 65, 12)");
 });


### PR DESCRIPTION
## Summary

Follow-up after the Social PR Autopilot merge to make the frontend local run path clearer, verify Tailwind is actually applied in browser tests, and resolve the post-merge review feedback.

The conflict happened because this branch still contained commits that were already merged into `feat/b2b-momentum-radar-frontend` through PR #120. I rebased this PR onto the latest base and kept the newest follow-up changes as the active branch history.

## Changes

- Added `dev:local` and `start:local` frontend scripts pointing at backend `8102` and frontend `3102`.
- Added a Playwright-only `dev:test` frontend script on `3112` so browser tests do not collide with a local dashboard on `3102`.
- Updated Playwright to use the explicit test frontend script.
- Added computed-style assertions for Tailwind-loaded body background, H1 weight, and primary button color.
- Documented that the repo root Vercel preview is a separate `zxy3` app unless Vercel is configured to use `social-pr-autopilot/frontend` as the project root.
- Updated the Makefile frontend target to use `npm run dev:local`.
- Added shared backend HTTP clients for AI providers and channel adapters, with graceful FastAPI lifespan shutdown.
- Cached Bluesky sessions and retry once after a 401 by reauthenticating.
- Updated Bluesky timestamps to use the AT Protocol `Z` UTC suffix.
- Added a backend contract test for the Bluesky timestamp format.

## Validation

- `/tmp/zxy-agent-apps-venv/bin/python -m pytest social-pr-autopilot/backend/tests` passed: 7 tests passed.
- `/tmp/zxy-agent-apps-venv/bin/python -m compileall -q social-pr-autopilot/backend/app` passed.
- `npm --prefix social-pr-autopilot/frontend run build` passed.
- `npm --prefix social-pr-autopilot/tests test` passed: 1 test passed.
- `git diff --check` passed.
